### PR TITLE
[Init] Spring Security 및 Swagger 초기 세팅 (#3)

### DIFF
--- a/src/main/java/com/swyp3/skin/global/config/SecurityConfig.java
+++ b/src/main/java/com/swyp3/skin/global/config/SecurityConfig.java
@@ -1,4 +1,28 @@
 package com.swyp3.skin.global.config;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.web.SecurityFilterChain;
 
+@Configuration
+@EnableWebSecurity
 public class SecurityConfig {
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        http
+                .csrf(csrf -> csrf.disable()) // 기본 보안 설정 비활성화 (초기 세팅용)
+                .authorizeHttpRequests(auth -> auth
+                        .requestMatchers(
+                                "/swagger-ui/**",
+                                "/swagger-ui.html",
+                                "/v3/api-docs/**",
+                                "/api-docs/**"
+                        ).permitAll()
+                        .anyRequest().authenticated()
+                );
+
+        return http.build();
+    }
 }

--- a/src/main/java/com/swyp3/skin/global/config/SwaggerConfig.java
+++ b/src/main/java/com/swyp3/skin/global/config/SwaggerConfig.java
@@ -1,4 +1,18 @@
 package com.swyp3.skin.global.config;
 
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
 public class SwaggerConfig {
+    @Bean
+    public OpenAPI openAPI() {
+        return new OpenAPI()
+                .info(new Info()
+                        .title("스킨 서비스 API 명세서")
+                        .description("스킨 서비스 백엔드 API 문서입니다.")
+                        .version("1.0.0"));
+    }
 }


### PR DESCRIPTION
## 관련 이슈
closes #3

## 작업 내용
- Springdoc OpenAPI 라이브러리를 추가하여 Swagger API 문서화 초기 환경을 구축했습니다.
- Spring Security 초기 설정을 진행하며, Swagger UI 접속 경로에 대해 인증 없이 접근 가능하도록(`permitAll`) 설정했습니다.

## 변경 사항
- `build.gradle`: Springdoc OpenAPI 의존성 추가
- `SwaggerConfig.java`: API 명세서 기본 정보(타이틀, 설명, 버전) 세팅
- `SecurityConfig.java`: SecurityFilterChain 추가 및 Swagger 관련 URL 경로 개방

## 스크린샷 (UI 변경 시)
> (💡 팁: 아까 눈으로 확인하셨던 그 예쁜 '스웨거 접속 화면'을 캡처해서 이 줄을 지우고 복사+붙여넣기 하시면 팀원들이 아주 좋아할 겁니다!)

## 리뷰 요청 사항
- Swagger API 문서의 제목이나 설명 내용이 팀 컨벤션에 맞게 잘 들어갔는지 확인 부탁드립니다.
- SecurityConfig에서 초기 세팅으로 Swagger 관련 경로만 열어두었는데, 문제 있으시다면 코멘트 부탁드립니다!

##참고
swagger 접속 하실 떄 " http://localhost:8080/swagger-ui/index.html "로 접속하시면 됩니다!

## 체크리스트
- [x] 컨벤션에 맞게 작성했나요?
- [x] 불필요한 코드(주석, 디버그 로그)를 제거했나요?
- [x] 테스트를 완료했나요?