### PR TITLE
fix: 프론트엔드 배포 도메인 확정에 따른 리다이렉트 주소 변경(#37)

### DIFF
--- a/src/main/java/com/swyp3/skin/global/auth/OAuth2SuccessHandler.java
+++ b/src/main/java/com/swyp3/skin/global/auth/OAuth2SuccessHandler.java
@@ -36,7 +36,7 @@ public class OAuth2SuccessHandler implements AuthenticationSuccessHandler {
         //2. JWT 토큰 발급
         String accessToken = jwtTokenProvider.createAccessToken(userId);
 
-        String targetUrl = "http://localhost:8080/swagger-ui/index.html";
+        String targetUrl = "https://api.layerd.co.kr/";
 
         SavedRequest savedRequest = requestCache.getRequest(request, response);
 
@@ -53,6 +53,6 @@ public class OAuth2SuccessHandler implements AuthenticationSuccessHandler {
                 .queryParam("accessToken", accessToken)
                 .build().toUriString();
 
-        response.sendRedirect(targetUrl);
+        response.sendRedirect(redirectUrl);
     }
 }

--- a/src/main/resources/application-local.yaml
+++ b/src/main/resources/application-local.yaml
@@ -24,11 +24,12 @@ spring:
           google:
             client-id: ${GOOGLE_CLIENT_ID}
             client-secret: ${GOOGLE_CLIENT_SECRET}
+            redirect-uri: "https://api.layerd.co.kr/login/oauth2/code/google"
             scope: [email, profile]
           kakao:
             client-id: ${KAKAO_CLIENT_ID}
             client-secret: ${KAKAO_CLIENT_SECRET}
-            redirect-uri: "{baseUrl}/login/oauth2/code/kakao"
+            redirect-uri: "https://api.layerd.co.kr/login/oauth2/code/kakao"
             authorization-grant-type: authorization_code
             client-authentication-method: client_secret_post
             client-name: Kakao


### PR DESCRIPTION
## 관련 이슈
closes #37

## 작업 내용
> 구현한 내용을 간단히 설명해주세요

## 변경 사항
-OAuth2SuccessHandler 수정

targetUrl을 실제 서비스 도메인(https://api.layerd.co.kr/)으로 업데이트

application.yml 설정 보완
-카카오 및 구글의 redirect-uri를 확정된 도메인 주소로 명시적 설정

## 스크린샷 (UI 변경 시)

## 리뷰 요청 사항
> 리뷰어가 집중해서 봐줬으면 하는 부분

## 체크리스트
- [x] 컨벤션에 맞게 작성했나요?
- [x] 불필요한 코드(주석, 디버그 로그)를 제거했나요?
- [x] 테스트를 완료했나요?