### PR TITLE
Refacotr/65 oauth2 uri ridierct jwt

### DIFF
--- a/src/main/java/com/swyp3/skin/global/auth/CustomOAuth2UserService.java
+++ b/src/main/java/com/swyp3/skin/global/auth/CustomOAuth2UserService.java
@@ -49,7 +49,7 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
         } else if ("kakao".equals(registrationId)) {
             providerUserId = String.valueOf(attributes.get("id"));
             Map<String, Object> kakaoAccount = (Map<String, Object>) attributes.get("kakao_account");
-            Map<String, Object> properties = (Map<String, Object>) attributes.get("properties");
+            Map<String, Object> properties = (Map<String, Object>) attributes.get("profile");
 
             if (kakaoAccount != null) {
                 email = (String) kakaoAccount.get("email");

--- a/src/main/java/com/swyp3/skin/global/auth/OAuth2SuccessHandler.java
+++ b/src/main/java/com/swyp3/skin/global/auth/OAuth2SuccessHandler.java
@@ -28,31 +28,19 @@ public class OAuth2SuccessHandler implements AuthenticationSuccessHandler {
     public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response,
                                         Authentication authentication) throws IOException, ServletException {
 
-        // 1. 유저 정보 가져오기
         CustomUserDetails userDetails = (CustomUserDetails) authentication.getPrincipal();
         Long userId = userDetails.getUserId();
 
         log.info("로그인 성공! JWT 발급 시작. 유저 ID: {}", userId);
-        //2. JWT 토큰 발급
         String accessToken = jwtTokenProvider.createAccessToken(userId);
 
-        String targetUrl = "http://localhost:8080/swagger-ui/index.html";
+        String redirectUri = request.getParameter("redirect_uri");
 
-        SavedRequest savedRequest = requestCache.getRequest(request, response);
-
-        if (savedRequest != null) {
-            targetUrl = savedRequest.getRedirectUrl();
-            requestCache.removeRequest(request, response);
-            log.info("원래 가려던 목적지로 리다이렉트 합니다: {}", targetUrl);
-        } else {
-            log.info("원래 목적지가 없어 기본 목적지(스웨거)로 리다이렉트 합니다.");
+        if (redirectUri == null || redirectUri.isBlank()) {
+            redirectUri = "https://layerd.co.kr";
         }
 
-        // 3. 리다이렉트 주소 설정
-        String redirectUrl = UriComponentsBuilder.fromUriString(targetUrl)
-                .queryParam("accessToken", accessToken)
-                .build().toUriString();
+        String redirectUrl = UriComponentsBuilder.fromUriString(redirectUri)
 
-        response.sendRedirect(targetUrl);
     }
 }

--- a/src/main/java/com/swyp3/skin/global/auth/OAuth2SuccessHandler.java
+++ b/src/main/java/com/swyp3/skin/global/auth/OAuth2SuccessHandler.java
@@ -6,6 +6,7 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
 import org.springframework.security.web.savedrequest.HttpSessionRequestCache;
@@ -21,7 +22,10 @@ import java.io.IOException;
 @RequiredArgsConstructor
 public class OAuth2SuccessHandler implements AuthenticationSuccessHandler {
 
-    private final JwtTokenProvider jwtTokenProvider; // 주입 추가
+    @Value("${app.cookie.secure:false}")
+    private boolean cookieSecure;
+
+    private final JwtTokenProvider jwtTokenProvider;
 
     private final RequestCache requestCache = new HttpSessionRequestCache();
 
@@ -43,7 +47,7 @@ public class OAuth2SuccessHandler implements AuthenticationSuccessHandler {
 
         Cookie cookie = new Cookie("accessToken", accessToken);
         cookie.setHttpOnly(true);
-        cookie.setSecure(true);
+        cookie.setSecure(cookieSecure);
         cookie.setPath("/");
         cookie.setMaxAge(3600);
         response.addCookie(cookie);

--- a/src/main/java/com/swyp3/skin/global/auth/OAuth2SuccessHandler.java
+++ b/src/main/java/com/swyp3/skin/global/auth/OAuth2SuccessHandler.java
@@ -1,6 +1,7 @@
 package com.swyp3.skin.global.auth;
 
 import jakarta.servlet.ServletException;
+import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
@@ -40,7 +41,13 @@ public class OAuth2SuccessHandler implements AuthenticationSuccessHandler {
             redirectUri = "https://layerd.co.kr";
         }
 
-        String redirectUrl = UriComponentsBuilder.fromUriString(redirectUri)
+        Cookie cookie = new Cookie("accessToken", accessToken);
+        cookie.setHttpOnly(true);
+        cookie.setSecure(true);
+        cookie.setPath("/");
+        cookie.setMaxAge(3600);
+        response.addCookie(cookie);
 
+        response.sendRedirect(redirectUri);
     }
 }

--- a/src/main/resources/application-local.yaml
+++ b/src/main/resources/application-local.yaml
@@ -39,3 +39,7 @@ spring:
             token-uri: https://kauth.kakao.com/oauth/token
             user-info-uri: https://kapi.kakao.com/v2/user/me
             user-name-attribute: id
+
+app:
+  cookie:
+    secure: false

--- a/src/main/resources/application-prod.yaml
+++ b/src/main/resources/application-prod.yaml
@@ -54,3 +54,7 @@ spring:
             token-uri: https://kauth.kakao.com/oauth/token
             user-info-uri: https://kapi.kakao.com/v2/user/me
             user-name-attribute: id
+
+app:
+  cookie:
+    secure: false


### PR DESCRIPTION
## 관련 이슈
closes #65 

## 작업 내용
> 리다이렉트 url 프론트 요청에서 가져오기 , 엑세스토큰 쿠키에 추가 , properties -> profile
## 변경 사항
- 
-

## 스크린샷 (UI 변경 시)

## 리뷰 요청 사항
> 
```java
CustomUserDetails userDetails = (CustomUserDetails) authentication.getPrincipal();
        Long userId = userDetails.getUserId();

        log.info("로그인 성공! JWT 발급 시작. 유저 ID: {}", userId);
        String accessToken = jwtTokenProvider.createAccessToken(userId);

        String redirectUri = request.getParameter("redirect_uri");

        if (redirectUri == null || redirectUri.isBlank()) {
            redirectUri = "https://layerd.co.kr";
        }

        Cookie cookie = new Cookie("accessToken", accessToken);
        cookie.setHttpOnly(true);
        cookie.setSecure(cookieSecure);
        cookie.setPath("/");
        cookie.setMaxAge(3600);
        response.addCookie(cookie);

        response.sendRedirect(redirectUri);
```
핸들러 확인해보시면 request에서 프론트가 보내온 리다이렉트 uri를 활용하여 사용자 이동시킵니다 
+ 쿠키에 엑세스토큰을 담아 보냅니다 => 추후 인가기능 설정시에 쿠키에서 꺼내 확인하기 
+ cookie.setSecure(cookieSecure); 설정은 https에서만 통신할지인데요 운영환경에 따라 분리해놨으니 참고바랍니다 

서비스의 properties -> profile 로 수정완료하였습니다 
+ 로컬에서 로그인 테스트 성공

이후 작업사항
- 인가 구현 
- user_profile에 name추가 

## 체크리스트
- [ ] 컨벤션에 맞게 작성했나요?
- [ ] 불필요한 코드(주석, 디버그 로그)를 제거했나요?
- [ ] 테스트를 완료했나요?