### PR TITLE
Refactor/89 skin result concerns filed

### DIFF
--- a/src/main/java/com/swyp3/skin/domain/skinresult/domain/entity/SkinResult.java
+++ b/src/main/java/com/swyp3/skin/domain/skinresult/domain/entity/SkinResult.java
@@ -1,5 +1,6 @@
 package com.swyp3.skin.domain.skinresult.domain.entity;
 
+import com.swyp3.skin.domain.skinresult.domain.enums.Concern;
 import com.swyp3.skin.domain.skinresult.domain.enums.SkinType;
 import com.swyp3.skin.domain.user.domain.entity.User;
 import com.swyp3.skin.global.entity.BaseEntity;
@@ -9,6 +10,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 @Entity
 @Getter
@@ -28,13 +30,23 @@ public class SkinResult extends BaseEntity {
     @Column(nullable = false)
     private String summary;
 
+    @ElementCollection
+    @CollectionTable(
+            name = "skin_result_concern",
+            joinColumns = @JoinColumn(name = "skin_result_id", nullable = false)
+    )
+    @Column(name = "concern", nullable = false)
+    @Enumerated(EnumType.STRING)
+    private List<Concern> concerns;
+
     @Column(nullable = false)
     private LocalDateTime diagnosedAt;
 
-    private SkinResult(User user, SkinType skinType, String summary, LocalDateTime diagnosedAt) {
+    private SkinResult(User user, SkinType skinType, String summary, List<Concern> concerns,LocalDateTime diagnosedAt) {
         this.user = user;
         this.skinType = skinType;
         this.summary = summary;
+        this.concerns = concerns;
         this.diagnosedAt = diagnosedAt;
     }
 
@@ -42,7 +54,8 @@ public class SkinResult extends BaseEntity {
             User user,
             SkinType skinType,
             String summary,
+            List<Concern> concerns,
             LocalDateTime diagnosedAt) {
-        return new SkinResult(user, skinType, summary, diagnosedAt);
+        return new SkinResult(user, skinType, summary,concerns ,diagnosedAt);
     }
 }

--- a/src/main/java/com/swyp3/skin/domain/skinresult/service/SkinResultService.java
+++ b/src/main/java/com/swyp3/skin/domain/skinresult/service/SkinResultService.java
@@ -21,7 +21,7 @@ public class SkinResultService {
     @Transactional
     public SkinResult save(User user, SkinPreviewCacheValue cached) {
         SkinResult skinResult = SkinResult.create(
-                user, cached.skinInput().getSkinType(), cached.summary(), LocalDateTime.now()
+                user, cached.skinInput().getSkinType(), cached.summary(), cached.skinInput().getConcerns(),LocalDateTime.now()
         );
         return skinResultRepository.save(skinResult);
     }

--- a/src/main/resources/db/migration/V5__add_skin_result_concern.sql
+++ b/src/main/resources/db/migration/V5__add_skin_result_concern.sql
@@ -1,0 +1,12 @@
+CREATE TABLE skin_result_concern
+(
+    skin_result_id BIGINT      NOT NULL,
+    concern        VARCHAR(50) NOT NULL,
+
+    PRIMARY KEY (skin_result_id, concern),
+
+    CONSTRAINT fk_skin_result_concern_skin_result_id
+        FOREIGN KEY (skin_result_id)
+        REFERENCES skin_result (id)
+        ON DELETE CASCADE
+);


### PR DESCRIPTION
## 관련 이슈
closes #89 

## 작업 내용
> 추후 UI스냅샷 용도로 사용자가 선택한 고민을 지속 사용할일이 발생 예견되어 SkinResult에 고민 필드도 추가 하였습니다

## 변경 사항
```java
@ElementCollection
@CollectionTable(
    name = "skin_result_concern",
    joinColumns = @JoinColumn(name = "skin_result_id", nullable = false)
)
@Column(name = "concern", nullable = false)
@Enumerated(EnumType.STRING)
private List<Concern> concerns;
```
엔티티에 위에 필드 추가 별도 엔티티 구성하지 않은 이유는 스냅샷 용도로만 사용되기에 간편하게 사용하기 위함

스키마 맞추기 위해 V5 생성하여 
```sql
CREATE TABLE skin_result_concern
(
    skin_result_id BIGINT      NOT NULL,
    concern        VARCHAR(50) NOT NULL,

    PRIMARY KEY (skin_result_id, concern),

    CONSTRAINT fk_skin_result_concern_skin_result_id
        FOREIGN KEY (skin_result_id)
        REFERENCES skin_result (id)
        ON DELETE CASCADE
);
```
추가 
-

## 스크린샷 (UI 변경 시)

## 리뷰 요청 사항
> 리뷰어가 집중해서 봐줬으면 하는 부분

## 체크리스트
- [ ] 컨벤션에 맞게 작성했나요?
- [ ] 불필요한 코드(주석, 디버그 로그)를 제거했나요?
- [ ] 테스트를 완료했나요?