### PR TITLE
Feat/101 routine api

### DIFF
--- a/src/main/java/com/swyp3/skin/api/v1/routine/controller/RoutineController.java
+++ b/src/main/java/com/swyp3/skin/api/v1/routine/controller/RoutineController.java
@@ -1,13 +1,22 @@
 package com.swyp3.skin.api.v1.routine.controller;
 
-import com.swyp3.skin.api.v1.routine.dto.response.RoutineDetailResponse;
-import com.swyp3.skin.api.v1.routine.dto.response.RoutineListResponse;
-import com.swyp3.skin.api.v1.routine.dto.response.RoutineRecommendationResponse;
-import com.swyp3.skin.api.v1.routine.dto.response.SaveRoutineResponse;
+import com.swyp3.skin.api.v1.routine.dto.request.SaveRoutineRequest;
+import com.swyp3.skin.api.v1.routine.dto.response.*;
+import com.swyp3.skin.domain.routine.dto.RoutinePreviewCacheValue;
+import com.swyp3.skin.domain.routine.service.*;
+import com.swyp3.skin.domain.skinresult.domain.entity.SkinResult;
+import com.swyp3.skin.domain.skinresult.service.SkinResultService;
+import com.swyp3.skin.global.auth.CustomUserDetails;
 import com.swyp3.skin.global.response.dto.ApiResponse;
+import com.swyp3.skin.recommendation.product.dto.RecommendedProduct;
+import com.swyp3.skin.recommendation.product.service.ProductRecommendationService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -15,23 +24,37 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
 @Tag(name = "Routine", description = "루틴 추천 및 저장 관리")
+@RequiredArgsConstructor
 @RestController
 @RequestMapping("/api/v1/routines")
 public class RoutineController {
+
+    private final SkinResultService skinResultService;
+    private final ProductRecommendationService productRecommendationService;
+    private final RoutineRecommendationService routineRecommendationService;
+    private final RoutineCommandService routineCommandService;
+    private final RoutineQueryService routineQueryService;
+    private final RoutinePreviewCacheService routinePreviewCacheService;
 
     @Operation(
             summary = "맞춤형 루틴 추천",
             description = "최신 피부 진단 결과를 기반으로 사용자의 AM/PM 루틴 미리보기 정보를 반환"
     )
     @GetMapping("/recommendation")
-    public ApiResponse<RoutineRecommendationResponse> getRecommendation() {
-        // TODO:
-        // 최신 피부 진단 결과 조회
-        // 추천 엔진으로 AM/PM 루틴 계산
-        // 추천 결과를 세션 또는 임시 저장소에 보관
-        // 응답 DTO로 반환
-        return null;
+    public ApiResponse<RoutineRecommendationWithTokenResponse> getRecommendation(
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        Long userId = userDetails.userId();
+        SkinResult latestSkinResult = skinResultService.getLatestByUserId(userId);
+        List<RecommendedProduct> recommended = productRecommendationService.recommend(latestSkinResult.getId());
+        RoutineRecommendationResponse response = routineRecommendationService.recommend(recommended, latestSkinResult);
+        String previewToken = routinePreviewCacheService.put(new RoutinePreviewCacheValue(userId, response));
+
+        return ApiResponse.ok(new RoutineRecommendationWithTokenResponse(response, previewToken));
     }
 
     @Operation(

--- a/src/main/java/com/swyp3/skin/api/v1/routine/controller/RoutineController.java
+++ b/src/main/java/com/swyp3/skin/api/v1/routine/controller/RoutineController.java
@@ -62,15 +62,12 @@ public class RoutineController {
             description = "직전에 추천된 AM/PM 루틴 결과를 그대로 사용자의 루틴으로 저장"
     )
     @PostMapping
-    public ApiResponse<SaveRoutineResponse> saveRoutine(){
-        // TODO :
-        // 직전 생성된 루틴 추천 결과 조회
-        // 추천 결과 없으면 예외처리(ex.생성된 루틴이 없습니다)
-        // 루틴 그룹 생성
-        // 생성 루틴 그룹 기준으로 각 타입별 루틴 저장
-        // 각 루틴 하위 루틴 프로덕트 저장
-        // 저장 완료 응답 DTO반환
-        return null;
+    public ApiResponse<SaveRoutineResponse> saveRoutine(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @Valid @RequestBody SaveRoutineRequest request
+    ){
+        SaveRoutineResponse saveRoutineResponse = routineCommandService.save(userDetails, request);
+        return ApiResponse.ok(saveRoutineResponse);
     }
 
     @Operation(
@@ -79,13 +76,13 @@ public class RoutineController {
     )
     @GetMapping
     public ApiResponse<RoutineListResponse> getRoutines(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
             @RequestParam(defaultValue = "0") int page,
             @RequestParam(defaultValue = "10") int size
     ) {
-        // TODO :
-        // 사용자 루틴 목록 조회
-        // 페이지 응답 DTO로 반환
-        return null;
+        Long userId = userDetails.userId();
+        RoutineListResponse response = routineQueryService.inquiryRoutineGroups(userId, page, size);
+        return ApiResponse.ok(response);
     }
 
     @Operation(
@@ -93,27 +90,24 @@ public class RoutineController {
             description = "선택한 루틴의 AM/PM 구성, 사용 순서, 추천 이유, 주의사항을 함께 조회"
     )
     @GetMapping("/{routineGroupId}")
-    public ApiResponse<RoutineDetailResponse> getRoutine(@PathVariable Long routineGroupId) {
-        // TODO :
-        // 루틴그룹 아이디 기준 루틴 그룹 조회
-        // 그룹에 속한 각 루틴 조회
-        // 각 루틴에 포함된 루틴 프로덕트 조회
-        // 응답 DTO로 반환
-        return null;
+    public ApiResponse<RoutineDetailResponse> getDetailRoutine(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @PathVariable Long routineGroupId) {
+        RoutineDetailResponse response = routineQueryService.inquiryDetailRoutineGroup(userDetails.userId(), routineGroupId);
+        return ApiResponse.ok(response);
     }
+
     @Operation(
             summary = "루틴 삭제",
             description = "선택한 루틴 기준으로 동일 그룹의 AM/PM 루틴과 하위 데이터를 함께 삭제"
     )
     @DeleteMapping("/{routineGroupId}")
     public ApiResponse<Void> deleteRoutine(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
             @Parameter(description = "삭제할 루틴 대표 ID", example = "1")
             @PathVariable Long routineGroupId
     ) {
-        // TODO:
-        // 그룹아이디 기준 삭제 대상 조회
-        // 그룹에 속한 루틴및 루틴 프로덕트 삭제
-        // 루틴 그룹 삭제
+        routineCommandService.deleteRoutine(routineGroupId, userDetails.userId());
         return ApiResponse.ok();
     }
 }

--- a/src/main/java/com/swyp3/skin/api/v1/routine/dto/request/SaveRoutineRequest.java
+++ b/src/main/java/com/swyp3/skin/api/v1/routine/dto/request/SaveRoutineRequest.java
@@ -1,0 +1,18 @@
+package com.swyp3.skin.api.v1.routine.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+@Schema(description = "루틴 저장 요청")
+public record SaveRoutineRequest(
+        @NotBlank
+        @Schema(description = "사용자가 입력한 루틴 제목", example = "건조 피부 관리 루틴")
+        @Size(max = 100)
+        String title,
+
+        @NotBlank
+        @Schema(description = "루틴 미리보기 토큰", example = "3f8e4f3f-54d8-4a21-a20f-0fce8d2cc9a1")
+        String previewToken
+) {
+}

--- a/src/main/java/com/swyp3/skin/api/v1/routine/dto/response/RoutineDetailResponse.java
+++ b/src/main/java/com/swyp3/skin/api/v1/routine/dto/response/RoutineDetailResponse.java
@@ -11,20 +11,20 @@ public record RoutineDetailResponse(
         @Schema(description = "루틴 그룹 ID", example = "21")
         Long routineGroupId,
 
-        @Schema(description = "루틴 제목", example = "민감 피부 데일리 루틴")
-        String title,
-
         @Schema(description = "기준 피부 진단 결과 ID", example = "7")
         Long skinResultId,
 
-        @Schema(description = "기준 피부 타입", example = "SENSITIVE")
+        @Schema(description = "루틴 제목", example = "민감 피부 데일리 루틴")
+        String title,
+
+        @Schema(description = "유형명", example = "촉촉한 수분 결핍형")
         String skinType,
 
-        @Schema(description = "루틴 전체 요약", example = "민감도가 높아 진정과 장벽 회복 중심으로 구성한 루틴입니다.")
-        String summary,
+        @Schema(description = "피부 타입 설명", example = "장벽까지 같이 약해진 상태예요.")
+        String subtitle,
 
-        @Schema(description = "주의사항", example = "아침 루틴 마지막 단계에서 자외선 차단제를 꼭 사용하세요.")
-        String caution,
+        @Schema(description = "루틴 설명", example =  "수분이 부족해지면 피부 장벽도 함께 약해져요. 보습제를 발라도 금방 건조해지는 이유가 바로 이 악순환 때문이에요. 수분을 채우면서 장벽을 복구하는 이중 케어가 필요해요.")
+        String routineSummary,
 
         @Schema(description = "AM 루틴 구성")
         RoutineSectionResponse amRoutine,

--- a/src/main/java/com/swyp3/skin/api/v1/routine/dto/response/RoutineRecommendationResponse.java
+++ b/src/main/java/com/swyp3/skin/api/v1/routine/dto/response/RoutineRecommendationResponse.java
@@ -6,17 +6,14 @@ public record RoutineRecommendationResponse(
         @Schema(description = "기준 피부 진단 결과 ID", example = "7")
         Long skinResultId,
 
-        @Schema(description = "기준 피부 타입", example = "SENSITIVE")
+        @Schema(description = "유형명", example = "촉촉한 수분 결핍형")
         String skinType,
 
-        @Schema(description = "루틴 제목", example = "민감 피부 데일리 루틴")
-        String title,
+        @Schema(description = "피부 타입 설명", example = "속은 건조한데 겉은 번들거려요.")
+        String subtitle,
 
-        @Schema(description = "루틴 전체 요약", example = "아침에는 진정과 수분 공급, 저녁에는 장벽 회복 중심으로 구성한 루틴입니다")
-        String summary,
-
-        @Schema(description = "루틴 사용 시 주의사항", example = "저녁 루틴의 액티브 성분은 주 2~3회부터 시작하세요")
-        String caution,
+        @Schema(description = "루틴 설명", example =  "수분이 부족해지면 피부 장벽도 함께 약해져요. 보습제를 발라도 금방 건조해지는 이유가 바로 이 악순환 때문이에요. 수분을 채우면서 장벽을 복구하는 이중 케어가 필요해요.")
+        String routineSummary,
 
         @Schema(description = "AM 루틴 구성")
         RoutineSectionResponse amRoutine,

--- a/src/main/java/com/swyp3/skin/api/v1/routine/dto/response/RoutineRecommendationWithTokenResponse.java
+++ b/src/main/java/com/swyp3/skin/api/v1/routine/dto/response/RoutineRecommendationWithTokenResponse.java
@@ -1,0 +1,13 @@
+package com.swyp3.skin.api.v1.routine.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "루틴 추천 미리보기 응답")
+public record RoutineRecommendationWithTokenResponse(
+        @Schema(description = "루틴 추천 결과", requiredMode = Schema.RequiredMode.REQUIRED)
+        RoutineRecommendationResponse recommendation,
+
+        @Schema(description = "저장 시 사용하는 루틴 미리보기 토큰", example = "3f8e4f3f-54d8-4a21-a20f-0fce8d2cc9a1")
+        String previewToken
+) {
+}

--- a/src/main/java/com/swyp3/skin/api/v1/routine/dto/response/RoutineRecommendedProductResponse.java
+++ b/src/main/java/com/swyp3/skin/api/v1/routine/dto/response/RoutineRecommendedProductResponse.java
@@ -1,5 +1,7 @@
 package com.swyp3.skin.api.v1.routine.dto.response;
 
+import com.swyp3.skin.domain.product.domain.enums.ProductCategory;
+import com.swyp3.skin.domain.routine.domain.enums.RoutineStepCategory;
 import io.swagger.v3.oas.annotations.media.Schema;
 
 @Schema(description = "루틴 추천/상세에서 사용하는 제품 정보")
@@ -11,22 +13,13 @@ public record RoutineRecommendedProductResponse(
         @Schema(description = "제품명", example = "시카 진정 토너")
         String name,
 
-        @Schema(description = "브랜드명", example = "SKINLAB")
-        String brand,
-
-        @Schema(description = "제품 카테고리", example = "TONER")
-        String category,
+        @Schema(description = "상품 원래 카테고리", example = "TONER")
+        ProductCategory productCategory,
 
         @Schema(description = "제품 대표 이미지 URL", example = "https://cdn.example.com/products/12.png")
         String imageUrl,
 
-        @Schema(description = "루틴 내 사용 순서", example = "1")
-        Integer sortOrder,
-
-        @Schema(description = "추천 이유", example = "민감한 피부를 진정시키는 성분이 포함되어 첫 단계에 적합합니다.")
-        String reason,
-
-        @Schema(description = "사용 포인트", example = "손바닥에 덜어 가볍게 눌러 흡수시켜 주세요.")
-        String note
+        @Schema(description = "루틴 단계 카테고리", example = "MOISTURIZER")
+        RoutineStepCategory routineStepCategory
 ) {
 }

--- a/src/main/java/com/swyp3/skin/api/v1/routine/dto/response/RoutineSectionResponse.java
+++ b/src/main/java/com/swyp3/skin/api/v1/routine/dto/response/RoutineSectionResponse.java
@@ -10,14 +10,8 @@ import java.util.List;
 @Schema(description = "AM 또는 PM 루틴 구성 정보")
 public record RoutineSectionResponse(
 
-        @Schema(description = "루틴 ID", example = "31")
-        Long routineId,
-
         @Schema(description = "루틴 타입", example = "AM")
         RoutineType routineType,
-
-        @Schema(description = "루틴 메모", example = "아침에는 자극이 적은 보습 중심으로 사용합니다.")
-        String memo,
 
         @ArraySchema(
                 schema = @Schema(implementation = RoutineRecommendedProductResponse.class),

--- a/src/main/java/com/swyp3/skin/api/v1/routine/dto/response/RoutineSummaryResponse.java
+++ b/src/main/java/com/swyp3/skin/api/v1/routine/dto/response/RoutineSummaryResponse.java
@@ -13,18 +13,6 @@ public record RoutineSummaryResponse(
         @Schema(description = "루틴 제목", example = "민감 피부 데일리 루틴")
         String title,
 
-        @Schema(description = "기준 피부 타입", example = "SENSITIVE")
-        String skinType,
-
-        @Schema(description = "루틴 전체 요약", example = "아침 진정, 저녁 장벽 회복 중심")
-        String summary,
-
-        @Schema(description = "AM 루틴 ID", example = "31")
-        Long amRoutineId,
-
-        @Schema(description = "PM 루틴 ID", example = "32")
-        Long pmRoutineId,
-
         @Schema(description = "생성 시각", example = "2026-04-05T14:30:00")
         LocalDateTime createdAt
 ) {

--- a/src/main/java/com/swyp3/skin/api/v1/skintest/controller/SkinTestController.java
+++ b/src/main/java/com/swyp3/skin/api/v1/skintest/controller/SkinTestController.java
@@ -87,7 +87,7 @@ public class SkinTestController {
             @AuthenticationPrincipal CustomUserDetails customUserDetails,
             @PathVariable Long resultId
     ) {
-        SkinResult skinResult = skinResultService.findByIdAndUserId(resultId, customUserDetails.userId());
+        SkinResult skinResult = skinResultService.getSkinResultById(resultId, customUserDetails.userId());
         SkinTestResultResponse response =
                 resultResponseMapper.toResponse(skinResult);
 

--- a/src/main/java/com/swyp3/skin/api/v1/skintest/controller/SkinTestController.java
+++ b/src/main/java/com/swyp3/skin/api/v1/skintest/controller/SkinTestController.java
@@ -60,7 +60,7 @@ public class SkinTestController {
         RecommendationResult result = skinTestApplicationService.calculate(skinInput);
         SkinTestPreviewResponse response = previewResponseMapper.toResponse(result);
 
-        String token = skinPreviewCacheService.put(new SkinPreviewCacheValue(skinInput, result, response.typeName()));
+        String token = skinPreviewCacheService.put(new SkinPreviewCacheValue(skinInput, result, response.skinType()));
         return ApiResponse.ok(new SkinTestPreviewWithTokenResponse(response, token));
     }
 

--- a/src/main/java/com/swyp3/skin/api/v1/skintest/dto/response/SkinTestPreviewResponse.java
+++ b/src/main/java/com/swyp3/skin/api/v1/skintest/dto/response/SkinTestPreviewResponse.java
@@ -14,11 +14,11 @@ public record SkinTestPreviewResponse(
         @Schema(description = "진단 날짜(프리뷰 시점 기준 오늘)", example = "2026-04-22")
         String diagnosedDate,
 
-        @Schema(description = "타입 네임")
-        String typeName,
+        @Schema(description = "피부 유형명")
+        String skinType,
 
-        @Schema(description = "타입 설명")
-        String subTitle,
+        @Schema(description = "부제")
+        String subtitle,
 
         @Schema(description = "피부 설명")
         String summary
@@ -30,7 +30,7 @@ public record SkinTestPreviewResponse(
             ) {
         return new SkinTestPreviewResponse(
                 diagnosedDate,
-                skinUxProfile.typeName(),
+                skinUxProfile.skinType(),
                 skinUxProfile.subtitle(),
                 skinUxProfile.summary()
         );

--- a/src/main/java/com/swyp3/skin/api/v1/skintest/dto/response/SkinTestResultResponse.java
+++ b/src/main/java/com/swyp3/skin/api/v1/skintest/dto/response/SkinTestResultResponse.java
@@ -16,11 +16,11 @@ public record SkinTestResultResponse(
         @Schema(description = "진단 시각", example = "2026.04.22")
         String diagnosedAt,
 
-        @Schema(description = "타입 네임")
-        String typeName,
+        @Schema(description = "피부 유형명")
+        String skinType,
 
-        @Schema(description = "타입 설명")
-        String subTitle,
+        @Schema(description = "부제")
+        String subtitle,
 
         @Schema(description = "피부 설명")
         String summary,
@@ -31,7 +31,7 @@ public record SkinTestResultResponse(
         @Schema(description = "피부 고민 설명")
         String subSummary,
 
-        @Schema(description = "추천 성분및 섦명")
+        @Schema(description = "추천 성분 및 설명")
         List<IngredientMeta> ingredientMetas
 ) {
         public static SkinTestResultResponse of(
@@ -41,11 +41,11 @@ public record SkinTestResultResponse(
         ){
                 return new SkinTestResultResponse(
                         diagnosedAt,
-                        uxProfile.typeName(),
+                        uxProfile.skinType(),
                         uxProfile.subtitle(),
                         uxProfile.summary(),
                         uxProfile.concerns(),
-                        uxProfile.subSummary(),
+                        uxProfile.routineSummary(),
                         ingredientMetas
                 );
         }

--- a/src/main/java/com/swyp3/skin/domain/routine/domain/entity/Routine.java
+++ b/src/main/java/com/swyp3/skin/domain/routine/domain/entity/Routine.java
@@ -25,4 +25,14 @@ public class Routine extends BaseEntity {
 
     @Column(length = 500)
     private String memo;
+
+    public static Routine of(
+            RoutineGroup routineGroup,
+            RoutineType routineType
+    ) {
+        Routine routine = new Routine();
+        routine.routineGroup = routineGroup;
+        routine.routineType = routineType;
+        return routine;
+    }
 }

--- a/src/main/java/com/swyp3/skin/domain/routine/domain/entity/RoutineGroup.java
+++ b/src/main/java/com/swyp3/skin/domain/routine/domain/entity/RoutineGroup.java
@@ -28,9 +28,30 @@ public class RoutineGroup extends BaseEntity {
     @Column(nullable = false, length = 100)
     private String title;
 
+    @Column(nullable = false, length = 100)
+    private String skinType;
+
+    @Column(length = 100)
+    private String subtitle;
+
     @Column(length = 500)
     private String summary;
 
-    @Column(length = 500)
-    private String caution;
+    public static RoutineGroup of(
+            User user,
+            SkinResult skinResult,
+            String title,
+            String skinType,
+            String subtitle,
+            String summary
+    ) {
+        RoutineGroup routineGroup = new RoutineGroup();
+        routineGroup.user = user;
+        routineGroup.skinResult = skinResult;
+        routineGroup.title = title;
+        routineGroup.skinType = skinType;
+        routineGroup.subtitle = subtitle;
+        routineGroup.summary = summary;
+        return routineGroup;
+    }
 }

--- a/src/main/java/com/swyp3/skin/domain/routine/domain/entity/RoutineProduct.java
+++ b/src/main/java/com/swyp3/skin/domain/routine/domain/entity/RoutineProduct.java
@@ -33,16 +33,12 @@ public class RoutineProduct extends BaseEntity {
     public static RoutineProduct of(
             Routine routine,
             Product product,
-            RoutineStepCategory routineStepCategory,
-            String note,
-            String reason
+            RoutineStepCategory routineStepCategory
     ) {
         RoutineProduct routineProduct = new RoutineProduct();
         routineProduct.routine = routine;
         routineProduct.product = product;
         routineProduct.routineStepCategory = routineStepCategory;
-        routineProduct.note = note;
-        routineProduct.reason = reason;
         return routineProduct;
     }
 }

--- a/src/main/java/com/swyp3/skin/domain/routine/domain/entity/RoutineProduct.java
+++ b/src/main/java/com/swyp3/skin/domain/routine/domain/entity/RoutineProduct.java
@@ -1,6 +1,7 @@
 package com.swyp3.skin.domain.routine.domain.entity;
 
 import com.swyp3.skin.domain.product.domain.entity.Product;
+import com.swyp3.skin.domain.routine.domain.enums.RoutineStepCategory;
 import com.swyp3.skin.global.entity.BaseEntity;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
@@ -10,16 +11,38 @@ import lombok.NoArgsConstructor;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-class RoutineProduct extends BaseEntity {
+public class RoutineProduct extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
+
     @ManyToOne(fetch = FetchType.LAZY) @JoinColumn(nullable = false)
     private Routine routine;
+
     @ManyToOne(fetch = FetchType.LAZY) @JoinColumn(nullable = false)
     private Product product;
+
     @Column(nullable = false)
-    private Integer sortOrder;
+    @Enumerated(EnumType.STRING)
+    private RoutineStepCategory routineStepCategory;
+
     private String note;
+
     private String reason;
+
+    public static RoutineProduct of(
+            Routine routine,
+            Product product,
+            RoutineStepCategory routineStepCategory,
+            String note,
+            String reason
+    ) {
+        RoutineProduct routineProduct = new RoutineProduct();
+        routineProduct.routine = routine;
+        routineProduct.product = product;
+        routineProduct.routineStepCategory = routineStepCategory;
+        routineProduct.note = note;
+        routineProduct.reason = reason;
+        return routineProduct;
+    }
 }

--- a/src/main/java/com/swyp3/skin/domain/routine/domain/enums/RoutineStepCategory.java
+++ b/src/main/java/com/swyp3/skin/domain/routine/domain/enums/RoutineStepCategory.java
@@ -1,0 +1,30 @@
+package com.swyp3.skin.domain.routine.domain.enums;
+
+import com.swyp3.skin.domain.product.domain.enums.ProductCategory;
+import lombok.Getter;
+
+@Getter
+public enum RoutineStepCategory {
+
+    PREPARE(1, "세안 후 피부결을 정돈하고 다음 단계 흡수를 높여줘요. 수분을 빠르게 채우고 피부 pH를 맞춰주는 첫 번째 레이어에요."),
+    INTENSIVE_CARE(2, "피부 고민에 가장 직접적으로 작용하는 단계예요. 나에게 맞는 핵심 성분이 가장 고농도로 담겨 있어요."),
+    MOISTURIZER(3, "수분과 영야이 날아기지 않도록 마무리해줘요. 피부 상태에 따라 가벼운 로션부터 진한 크림까지 선택할 수 있어요."),
+    SUN_CARE(4, "낮 동안 자외선으로부터 피부를 보호해요. 어떤 루틴도 선크림 없이는 완성되지 않아요.");
+
+    private final int order;
+    private final String note;
+
+    RoutineStepCategory(int order, String note) {
+        this.order = order;
+        this.note = note;
+    }
+
+    public static RoutineStepCategory toRoutineStepCategory(ProductCategory category) {
+        return switch (category) {
+            case SKIN, TONER -> PREPARE;
+            case ESSENCE, SERUM, AMPOULE -> INTENSIVE_CARE;
+            case LOTION, EMULSION, CREAM -> MOISTURIZER;
+            case SUN_CARE -> SUN_CARE;
+        };
+    }
+}

--- a/src/main/java/com/swyp3/skin/domain/routine/domain/enums/RoutineType.java
+++ b/src/main/java/com/swyp3/skin/domain/routine/domain/enums/RoutineType.java
@@ -1,3 +1,16 @@
 package com.swyp3.skin.domain.routine.domain.enums;
 
-public enum RoutineType { AM, PM }
+import com.swyp3.skin.domain.product.domain.enums.ProductUsageTime;
+
+import java.util.List;
+
+public enum RoutineType { AM, PM;
+
+    public static List<RoutineType> from(ProductUsageTime usageTime) {
+        return switch (usageTime) {
+            case AM -> List.of(AM);
+            case PM -> List.of(PM);
+            case BOTH -> List.of(AM, PM);
+        };
+    }
+}

--- a/src/main/java/com/swyp3/skin/domain/routine/dto/RoutinePreviewCacheValue.java
+++ b/src/main/java/com/swyp3/skin/domain/routine/dto/RoutinePreviewCacheValue.java
@@ -1,0 +1,9 @@
+package com.swyp3.skin.domain.routine.dto;
+
+import com.swyp3.skin.api.v1.routine.dto.response.RoutineRecommendationResponse;
+
+public record RoutinePreviewCacheValue(
+        Long userId,
+        RoutineRecommendationResponse response
+) {
+}

--- a/src/main/java/com/swyp3/skin/domain/routine/exception/RoutineErrorCode.java
+++ b/src/main/java/com/swyp3/skin/domain/routine/exception/RoutineErrorCode.java
@@ -1,0 +1,25 @@
+package com.swyp3.skin.domain.routine.exception;
+
+import com.swyp3.skin.global.exception.ErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum RoutineErrorCode implements ErrorCode {
+    PREVIEW_TOKEN_EXPIRED(HttpStatus.BAD_REQUEST, "ROUTINE_400_001", "미리보기 토큰이 만료되었거나 존재하지 않습니다."),
+    PREVIEW_RESPONSE_NOT_FOUND(HttpStatus.BAD_REQUEST, "ROUTINE_400_002", "루틴 미리보기 응답 데이터가 존재하지 않습니다."),
+    PREVIEW_ROUTINE_EMPTY(HttpStatus.BAD_REQUEST, "ROUTINE_400_003", "루틴 미리보기 데이터에 AM/PM 루틴이 존재하지 않습니다."),
+    PREVIEW_SECTION_INVALID(HttpStatus.BAD_REQUEST, "ROUTINE_400_004", "루틴 섹션 데이터가 올바르지 않습니다."),
+    PREVIEW_PRODUCT_INVALID(HttpStatus.BAD_REQUEST, "ROUTINE_400_005", "루틴에 포함된 상품 정보가 올바르지 않습니다."),
+    ROUTINE_NOT_FOUND(HttpStatus.NOT_FOUND, "ROUTINE_404_001", "존재하지 않는 루틴입니다."),
+    PREVIEW_CACHE_TYPE_MISMATCH(HttpStatus.INTERNAL_SERVER_ERROR,"ROUTINE_500_001" ,"캐시 값이 서버 지정값과 다릅니다." ),
+    PREVIEW_CACHE_NOT_FOUND(HttpStatus.INTERNAL_SERVER_ERROR, "ROUTINE_500_002", "루틴 미리보기 캐시를 찾을 수 없습니다."),
+    ROUTINE_UX_PROFILE_NOT_FOUND(HttpStatus.INTERNAL_SERVER_ERROR, "ROUTINE_500_003", "루틴 UX 프로파일 매핑이 존재하지 않습니다."),
+    ROUTINE_COMPOSITION_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "ROUTINE_500_004", "시간대별 루틴을 구성할 수 있는 추천 상품이 부족합니다.");
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/com/swyp3/skin/domain/routine/exception/RoutineException.java
+++ b/src/main/java/com/swyp3/skin/domain/routine/exception/RoutineException.java
@@ -1,0 +1,10 @@
+package com.swyp3.skin.domain.routine.exception;
+
+import com.swyp3.skin.global.exception.CustomException;
+import com.swyp3.skin.global.exception.ErrorCode;
+
+public class RoutineException extends CustomException {
+    public RoutineException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/com/swyp3/skin/domain/routine/repository/RoutineGroupRepository.java
+++ b/src/main/java/com/swyp3/skin/domain/routine/repository/RoutineGroupRepository.java
@@ -1,10 +1,15 @@
 package com.swyp3.skin.domain.routine.repository;
 
 import com.swyp3.skin.domain.routine.domain.entity.RoutineGroup;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface RoutineGroupRepository extends JpaRepository<RoutineGroup, Long> {
     List<RoutineGroup> findTop4ByUser_IdOrderByCreatedAtDesc(Long userId);
+    Page<RoutineGroup> findByUser_Id(Long userId, Pageable pageable);
+    Optional<RoutineGroup> findByIdAndUser_Id(Long routineGroupId, Long userId);
 }

--- a/src/main/java/com/swyp3/skin/domain/routine/repository/RoutineProductRepository.java
+++ b/src/main/java/com/swyp3/skin/domain/routine/repository/RoutineProductRepository.java
@@ -1,0 +1,11 @@
+package com.swyp3.skin.domain.routine.repository;
+
+import com.swyp3.skin.domain.routine.domain.entity.RoutineProduct;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface RoutineProductRepository extends JpaRepository<RoutineProduct, Long> {
+    List<RoutineProduct> findByRoutine_Id(Long routineId);
+    void deleteByRoutine_Id(Long routineId);
+}

--- a/src/main/java/com/swyp3/skin/domain/routine/repository/RoutineRepository.java
+++ b/src/main/java/com/swyp3/skin/domain/routine/repository/RoutineRepository.java
@@ -3,6 +3,9 @@ package com.swyp3.skin.domain.routine.repository;
 import com.swyp3.skin.domain.routine.domain.entity.Routine;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 
 public interface RoutineRepository extends JpaRepository<Routine, Long> {
+    List<Routine> findByRoutineGroup_Id(Long routineGroupId);
 }

--- a/src/main/java/com/swyp3/skin/domain/routine/service/RoutineCommandService.java
+++ b/src/main/java/com/swyp3/skin/domain/routine/service/RoutineCommandService.java
@@ -1,0 +1,152 @@
+package com.swyp3.skin.domain.routine.service;
+
+import com.swyp3.skin.api.v1.routine.dto.request.SaveRoutineRequest;
+import com.swyp3.skin.api.v1.routine.dto.response.RoutineRecommendationResponse;
+import com.swyp3.skin.api.v1.routine.dto.response.RoutineRecommendedProductResponse;
+import com.swyp3.skin.api.v1.routine.dto.response.RoutineSectionResponse;
+import com.swyp3.skin.api.v1.routine.dto.response.SaveRoutineResponse;
+import com.swyp3.skin.domain.product.domain.entity.Product;
+import com.swyp3.skin.domain.product.service.ProductService;
+import com.swyp3.skin.domain.routine.domain.entity.Routine;
+import com.swyp3.skin.domain.routine.domain.entity.RoutineGroup;
+import com.swyp3.skin.domain.routine.domain.entity.RoutineProduct;
+import com.swyp3.skin.domain.routine.domain.enums.RoutineStepCategory;
+import com.swyp3.skin.domain.routine.dto.RoutinePreviewCacheValue;
+import com.swyp3.skin.domain.routine.exception.RoutineErrorCode;
+import com.swyp3.skin.domain.routine.exception.RoutineException;
+import com.swyp3.skin.domain.routine.repository.RoutineGroupRepository;
+import com.swyp3.skin.domain.routine.repository.RoutineProductRepository;
+import com.swyp3.skin.domain.routine.repository.RoutineRepository;
+import com.swyp3.skin.domain.skinresult.domain.entity.SkinResult;
+import com.swyp3.skin.domain.skinresult.service.SkinResultService;
+import com.swyp3.skin.domain.user.domain.entity.User;
+import com.swyp3.skin.domain.user.service.UserService;
+import com.swyp3.skin.global.auth.CustomUserDetails;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+@RequiredArgsConstructor
+@Service
+public class RoutineCommandService {
+
+    private final RoutinePreviewCacheService routinePreviewCacheService;
+    private final UserService userService;
+    private final SkinResultService skinResultService;
+    private final ProductService productService;
+    private final RoutineGroupRepository routineGroupRepository;
+    private final RoutineRepository routineRepository;
+    private final RoutineProductRepository routineProductRepository;
+
+    @Transactional
+    public void deleteRoutine(Long routineGroupId, Long userId) {
+        routineGroupRepository.findByIdAndUser_Id(routineGroupId, userId)
+                .orElseThrow(() -> new RoutineException(RoutineErrorCode.ROUTINE_NOT_FOUND));
+
+        List<Routine> routines = routineRepository.findByRoutineGroup_Id(routineGroupId);
+        for (Routine routine : routines) {
+            routineProductRepository.deleteByRoutine_Id(routine.getId());
+            routineRepository.delete(routine);
+        }
+
+        routineGroupRepository.deleteById(routineGroupId);
+    }
+
+    @Transactional
+    public SaveRoutineResponse save(CustomUserDetails userDetails, SaveRoutineRequest request) {
+        RoutineRecommendationResponse response = resolveRoutineData(userDetails, request);
+
+        User user = userService.findById(userDetails.userId());
+        SkinResult skinResult = skinResultService.findByIdAndUserId(response.skinResultId(), userDetails.userId());
+
+        RoutineGroup routineGroup = routineGroupRepository.save(RoutineGroup.of(
+                user,
+                skinResult,
+                request.title(),
+                response.skinType(),
+                response.subtitle(),
+                response.routineSummary()
+        ));
+
+        saveSection(routineGroup, response.amRoutine());
+        saveSection(routineGroup, response.pmRoutine());
+
+        return new SaveRoutineResponse(
+                routineGroup.getId(),
+                request.title(),
+                "추천 루틴이 저장되었습니다."
+        );
+    }
+
+    private RoutineRecommendationResponse resolveRoutineData(CustomUserDetails userDetails, SaveRoutineRequest request) {
+        RoutinePreviewCacheValue cached = routinePreviewCacheService.consume(request.previewToken());
+        if (cached == null || !cached.userId().equals(userDetails.userId())) {
+            throw new RoutineException(RoutineErrorCode.PREVIEW_TOKEN_EXPIRED);
+        }
+
+        RoutineRecommendationResponse response = cached.response();
+        validatePreviewResponse(response);
+        return response;
+    }
+
+    private void validatePreviewResponse(RoutineRecommendationResponse response) {
+        if (response == null || response.skinResultId() == null) {
+            throw new RoutineException(RoutineErrorCode.PREVIEW_RESPONSE_NOT_FOUND);
+        }
+
+        if (response.amRoutine() == null || response.pmRoutine() == null) {
+            throw new RoutineException(RoutineErrorCode.PREVIEW_ROUTINE_EMPTY);
+        }
+
+        validateSection(response.amRoutine());
+        validateSection(response.pmRoutine());
+    }
+
+    private void validateSection(RoutineSectionResponse section) {
+        if (section.routineType() == null || section.products() == null || section.products().isEmpty()) {
+            throw new RoutineException(RoutineErrorCode.PREVIEW_SECTION_INVALID);
+        }
+
+        Set<RoutineStepCategory> stepCategories = new HashSet<>();
+        for (RoutineRecommendedProductResponse productResponse : section.products()) {
+            if (productResponse == null
+                    || productResponse.productId() == null
+                    || productResponse.routineStepCategory() == null
+                    || !stepCategories.add(productResponse.routineStepCategory())) {
+                throw new RoutineException(RoutineErrorCode.PREVIEW_PRODUCT_INVALID);
+            }
+        }
+    }
+
+    private void saveSection(RoutineGroup routineGroup, RoutineSectionResponse section) {
+        Routine routine = routineRepository.save(Routine.of(
+                routineGroup,
+                section.routineType()
+        ));
+
+        List<RoutineProduct> routineProducts = section.products().stream()
+                .map(productResponse -> toRoutineProduct(routine, productResponse))
+                .toList();
+
+        routineProductRepository.saveAll(routineProducts);
+    }
+
+    private RoutineProduct toRoutineProduct(
+            Routine routine,
+            RoutineRecommendedProductResponse productResponse
+    ) {
+        Product product = productService.getById(productResponse.productId());
+        RoutineStepCategory routineStepCategory = productResponse.routineStepCategory();
+        return RoutineProduct.of(
+                routine,
+                product,
+                routineStepCategory,
+                routineStepCategory.getNote(),
+                routineStepCategory.name()
+        );
+    }
+}

--- a/src/main/java/com/swyp3/skin/domain/routine/service/RoutineCommandService.java
+++ b/src/main/java/com/swyp3/skin/domain/routine/service/RoutineCommandService.java
@@ -144,9 +144,7 @@ public class RoutineCommandService {
         return RoutineProduct.of(
                 routine,
                 product,
-                routineStepCategory,
-                routineStepCategory.getNote(),
-                routineStepCategory.name()
+                routineStepCategory
         );
     }
 }

--- a/src/main/java/com/swyp3/skin/domain/routine/service/RoutineCommandService.java
+++ b/src/main/java/com/swyp3/skin/domain/routine/service/RoutineCommandService.java
@@ -61,7 +61,7 @@ public class RoutineCommandService {
         RoutineRecommendationResponse response = resolveRoutineData(userDetails, request);
 
         User user = userService.findById(userDetails.userId());
-        SkinResult skinResult = skinResultService.findByIdAndUserId(response.skinResultId(), userDetails.userId());
+        SkinResult skinResult = skinResultService.getSkinResultById(response.skinResultId(), userDetails.userId());
 
         RoutineGroup routineGroup = routineGroupRepository.save(RoutineGroup.of(
                 user,

--- a/src/main/java/com/swyp3/skin/domain/routine/service/RoutineCompositionService.java
+++ b/src/main/java/com/swyp3/skin/domain/routine/service/RoutineCompositionService.java
@@ -1,0 +1,86 @@
+package com.swyp3.skin.domain.routine.service;
+
+import com.swyp3.skin.domain.product.domain.entity.Product;
+import com.swyp3.skin.domain.product.domain.enums.ProductUsageTime;
+import com.swyp3.skin.domain.routine.domain.enums.RoutineStepCategory;
+import com.swyp3.skin.domain.routine.domain.enums.RoutineType;
+import com.swyp3.skin.recommendation.product.dto.RecommendedProduct;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.EnumMap;
+import java.util.List;
+import java.util.Map;
+
+@RequiredArgsConstructor
+@Service
+public class RoutineCompositionService {
+    //am pm 시간대가 모두 채워진다는 보장이 없음
+    //카테고리 별로 상품이 모두 채워져 있다는 보장이 없음
+
+    public Map<RoutineType, Map<RoutineStepCategory, List<RecommendedProduct>>> compose(List<RecommendedProduct> recommendedProducts) {
+        Map<RoutineType, List<RecommendedProduct>> productsByRoutineType =
+                groupProductsByRoutineType(recommendedProducts);
+        Map<RoutineType, Map<RoutineStepCategory, List<RecommendedProduct>>> productsByStepCategory =
+                groupProductsByStepCategory(productsByRoutineType);
+        sortProductsByScore(productsByStepCategory);
+
+        return productsByStepCategory;
+    }
+
+    private Map<RoutineType, List<RecommendedProduct>> groupProductsByRoutineType(
+            List<RecommendedProduct> recommendedProducts
+    ) {
+        Map<RoutineType, List<RecommendedProduct>> productsByRoutineType = new EnumMap<>(RoutineType.class);
+
+        for (RecommendedProduct recommendedProduct : recommendedProducts) {
+            ProductUsageTime usageTime = recommendedProduct.getProduct().getProductUsageTime();
+
+            for (RoutineType routineType : RoutineType.from(usageTime)) {
+                productsByRoutineType.computeIfAbsent(routineType, ignored -> new ArrayList<>())
+                        .add(recommendedProduct);
+            }
+        }
+        return productsByRoutineType;
+    }
+
+    private Map<RoutineType, Map<RoutineStepCategory, List<RecommendedProduct>>> groupProductsByStepCategory(
+            Map<RoutineType, List<RecommendedProduct>> productsByRoutineType
+    ) {
+        Map<RoutineType, Map<RoutineStepCategory, List<RecommendedProduct>>> productsByStepCategory =
+                new EnumMap<>(RoutineType.class);
+
+        for (Map.Entry<RoutineType, List<RecommendedProduct>> routineTypeEntry : productsByRoutineType.entrySet()) {
+            Map<RoutineStepCategory, List<RecommendedProduct>> productsForStepCategory =
+                    productsByStepCategory.computeIfAbsent(
+                            routineTypeEntry.getKey(),
+                            ignored -> new EnumMap<>(RoutineStepCategory.class)
+                    );
+
+            for (RecommendedProduct recommendedProduct : routineTypeEntry.getValue()) {
+                Product product = recommendedProduct.getProduct();
+                RoutineStepCategory routineStepCategory =
+                        RoutineStepCategory.toRoutineStepCategory(product.getCategory());
+
+                productsForStepCategory.computeIfAbsent(routineStepCategory, ignored -> new ArrayList<>())
+                        .add(recommendedProduct);
+            }
+        }
+        return productsByStepCategory;
+    }
+
+    private void sortProductsByScore(
+            Map<RoutineType, Map<RoutineStepCategory, List<RecommendedProduct>>> productsByStepCategory
+    ) {
+        for (Map<RoutineStepCategory, List<RecommendedProduct>> productsByCategory : productsByStepCategory.values()) {
+            for (Map.Entry<RoutineStepCategory, List<RecommendedProduct>> categoryEntry : productsByCategory.entrySet()) {
+                List<RecommendedProduct> sortedProducts = categoryEntry.getValue().stream()
+                        .sorted(Comparator.comparing(RecommendedProduct::getScore).reversed())
+                        .toList();
+                categoryEntry.setValue(sortedProducts);
+            }
+        }
+    }
+}

--- a/src/main/java/com/swyp3/skin/domain/routine/service/RoutinePreviewCacheService.java
+++ b/src/main/java/com/swyp3/skin/domain/routine/service/RoutinePreviewCacheService.java
@@ -1,0 +1,65 @@
+package com.swyp3.skin.domain.routine.service;
+
+import com.swyp3.skin.domain.routine.dto.RoutinePreviewCacheValue;
+import com.swyp3.skin.domain.routine.exception.RoutineErrorCode;
+import com.swyp3.skin.domain.routine.exception.RoutineException;
+import com.swyp3.skin.global.config.CacheConfig;
+import lombok.RequiredArgsConstructor;
+import org.springframework.cache.Cache;
+import org.springframework.cache.CacheManager;
+import org.springframework.stereotype.Service;
+
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class RoutinePreviewCacheService {
+
+    private final CacheManager cacheManager;
+
+    public String put(RoutinePreviewCacheValue value) {
+        String token = UUID.randomUUID().toString();
+        Cache cache = getCache();
+        cache.put(token, value);
+        return token;
+    }
+
+    private Cache getCache() {
+        Cache cache = cacheManager.getCache(CacheConfig.LAYERD_PREVIEW_CACHE);
+        if (cache == null) {
+            throw new RoutineException(RoutineErrorCode.PREVIEW_CACHE_NOT_FOUND);
+        }
+        return cache;
+    }
+
+    public RoutinePreviewCacheValue consume(String previewToken) {
+        Cache findCache = getCache();
+        Object nativeCache = findCache.getNativeCache();
+
+        if (!(nativeCache instanceof com.github.benmanes.caffeine.cache.Cache<?, ?> caffeineCache)) {
+            throw new RoutineException(RoutineErrorCode.PREVIEW_CACHE_TYPE_MISMATCH);
+        }
+
+        @SuppressWarnings("unchecked")
+        com.github.benmanes.caffeine.cache.Cache<Object, Object> cache =
+                (com.github.benmanes.caffeine.cache.Cache<Object, Object>) caffeineCache;
+
+        Object removed = cache.asMap().remove(previewToken);
+        return toRoutinePreviewCacheValue(removed);
+    }
+
+    public RoutinePreviewCacheValue get(String previewToken) {
+        Cache.ValueWrapper wrapper = getCache().get(previewToken);
+        return wrapper == null ? null : toRoutinePreviewCacheValue(wrapper.get());
+    }
+
+    private RoutinePreviewCacheValue toRoutinePreviewCacheValue(Object cachedValue) {
+        if (cachedValue == null) {
+            return null;
+        }
+        if (!(cachedValue instanceof RoutinePreviewCacheValue routinePreviewCacheValue)) {
+            throw new RoutineException(RoutineErrorCode.PREVIEW_CACHE_TYPE_MISMATCH);
+        }
+        return routinePreviewCacheValue;
+    }
+}

--- a/src/main/java/com/swyp3/skin/domain/routine/service/RoutineQueryService.java
+++ b/src/main/java/com/swyp3/skin/domain/routine/service/RoutineQueryService.java
@@ -1,0 +1,103 @@
+package com.swyp3.skin.domain.routine.service;
+
+import com.swyp3.skin.api.v1.routine.dto.response.RoutineDetailResponse;
+import com.swyp3.skin.api.v1.routine.dto.response.RoutineListResponse;
+import com.swyp3.skin.api.v1.routine.dto.response.RoutineRecommendedProductResponse;
+import com.swyp3.skin.api.v1.routine.dto.response.RoutineSectionResponse;
+import com.swyp3.skin.api.v1.routine.dto.response.RoutineSummaryResponse;
+import com.swyp3.skin.domain.routine.domain.entity.Routine;
+import com.swyp3.skin.domain.routine.domain.entity.RoutineGroup;
+import com.swyp3.skin.domain.routine.domain.entity.RoutineProduct;
+import com.swyp3.skin.domain.routine.domain.enums.RoutineType;
+import com.swyp3.skin.domain.routine.exception.RoutineErrorCode;
+import com.swyp3.skin.domain.routine.exception.RoutineException;
+import com.swyp3.skin.domain.routine.repository.RoutineGroupRepository;
+import com.swyp3.skin.domain.routine.repository.RoutineProductRepository;
+import com.swyp3.skin.domain.routine.repository.RoutineRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class RoutineQueryService {
+
+    private final RoutineGroupRepository routineGroupRepository;
+    private final RoutineRepository routineRepository;
+    private final RoutineProductRepository routineProductRepository;
+
+    public RoutineListResponse inquiryRoutineGroups(Long userId, int page, int size) {
+        PageRequest pageable = PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, "createdAt"));
+        Page<RoutineGroup> routineGroups = routineGroupRepository.findByUser_Id(userId, pageable);
+
+        List<RoutineSummaryResponse> routines = new ArrayList<>();
+        for(RoutineGroup routineGroup : routineGroups.getContent()) {
+            routines.add(new RoutineSummaryResponse(routineGroup.getId(),
+                    routineGroup.getTitle(), routineGroup.getCreatedAt()));
+        }
+        return new RoutineListResponse(
+                routines,
+                routineGroups.getNumber(),
+                routineGroups.getSize(),
+                routineGroups.getTotalElements(),
+                routineGroups.getTotalPages()
+        );
+    }
+
+    public RoutineDetailResponse inquiryDetailRoutineGroup(Long userId, Long routineGroupId) {
+        RoutineGroup routineGroup = routineGroupRepository.findByIdAndUser_Id(routineGroupId, userId).orElseThrow(
+                () -> new RoutineException(RoutineErrorCode.ROUTINE_NOT_FOUND));
+
+        List<Routine> routines = routineRepository.findByRoutineGroup_Id(routineGroup.getId());
+        RoutineSectionResponse amRoutine = null;
+        RoutineSectionResponse pmRoutine = null;
+
+        for(Routine routine : routines) {
+            List<RoutineProduct> products = routineProductRepository.findByRoutine_Id(routine.getId());
+            List<RoutineRecommendedProductResponse> routineProducts = products.stream()
+                    .sorted(Comparator.comparing(routineProduct -> routineProduct.getRoutineStepCategory().getOrder()))
+                    .map(this::toRoutineRecommendedProductResponse)
+                    .toList();
+
+            RoutineSectionResponse routineSectionResponse = new RoutineSectionResponse(
+                    routine.getRoutineType(),
+                    routineProducts
+            );
+
+            if (routine.getRoutineType() == RoutineType.AM) {
+                amRoutine = routineSectionResponse;
+            }
+            if (routine.getRoutineType() == RoutineType.PM) {
+                pmRoutine = routineSectionResponse;
+            }
+        }
+
+        return new RoutineDetailResponse(
+                routineGroup.getId(),
+                routineGroup.getSkinResult().getId(),
+                routineGroup.getTitle(),
+                routineGroup.getSkinType(),
+                routineGroup.getSubtitle(),
+                routineGroup.getSummary(),
+                amRoutine,
+                pmRoutine,
+                routineGroup.getCreatedAt()
+        );
+    }
+
+    private RoutineRecommendedProductResponse toRoutineRecommendedProductResponse(RoutineProduct routineProduct) {
+        return new RoutineRecommendedProductResponse(
+                routineProduct.getProduct().getId(),
+                routineProduct.getProduct().getName(),
+                routineProduct.getProduct().getCategory(),
+                routineProduct.getProduct().getImageUrl(),
+                routineProduct.getRoutineStepCategory()
+        );
+    }
+}

--- a/src/main/java/com/swyp3/skin/domain/routine/service/RoutineRecommendationService.java
+++ b/src/main/java/com/swyp3/skin/domain/routine/service/RoutineRecommendationService.java
@@ -1,0 +1,115 @@
+package com.swyp3.skin.domain.routine.service;
+
+import com.swyp3.skin.api.v1.routine.dto.response.*;
+import com.swyp3.skin.domain.common.enums.IngredientGroup;
+import com.swyp3.skin.domain.product.domain.entity.Product;
+import com.swyp3.skin.domain.routine.domain.enums.RoutineStepCategory;
+import com.swyp3.skin.domain.routine.domain.enums.RoutineType;
+import com.swyp3.skin.domain.routine.exception.RoutineErrorCode;
+import com.swyp3.skin.domain.routine.exception.RoutineException;
+import com.swyp3.skin.domain.skinresult.domain.entity.SkinResult;
+import com.swyp3.skin.domain.skinresult.domain.entity.SkinResultGroupScore;
+import com.swyp3.skin.domain.skinresult.repository.SkinResultGroupScoreRepository;
+import com.swyp3.skin.recommendation.product.dto.RecommendedProduct;
+import com.swyp3.skin.recommendation.ux.SkinUxKey;
+import com.swyp3.skin.recommendation.ux.SkinUxProfile;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import static com.swyp3.skin.recommendation.ux.SkinUxProfileRegistry.PROFILES;
+
+@Service
+@RequiredArgsConstructor
+public class RoutineRecommendationService {
+
+    private final RoutineCompositionService routineCompositionService;
+    private final SkinResultGroupScoreRepository skinResultGroupScoreRepository;
+
+    public RoutineRecommendationResponse recommend(
+        List<RecommendedProduct> recommendedProducts,
+        SkinResult skinResult) {
+        Map<RoutineType, Map<RoutineStepCategory, List<RecommendedProduct>>> productsByStepCategory =
+                routineCompositionService.compose(recommendedProducts);
+        return toRecommendationResponse(productsByStepCategory, skinResult);
+    }
+
+    private RoutineRecommendationResponse toRecommendationResponse(
+            Map<RoutineType, Map<RoutineStepCategory, List<RecommendedProduct>>> productsByStepCategory,
+            SkinResult skinResult
+    ) {
+        RoutineSectionResponse amRoutine = null;
+        RoutineSectionResponse pmRoutine = null;
+        SkinUxProfile uxProfile = resolveSkinUxProfile(skinResult);
+
+        for (Map.Entry<RoutineType, Map<RoutineStepCategory, List<RecommendedProduct>>> routineTypeEntry : productsByStepCategory.entrySet()) {
+            List<RoutineRecommendedProductResponse> routineProducts = new ArrayList<>();
+            for (Map.Entry<RoutineStepCategory, List<RecommendedProduct>> stepCategoryEntry : routineTypeEntry.getValue().entrySet()) {
+                routineProducts.add(toProductResponse(stepCategoryEntry.getValue().get(0), stepCategoryEntry.getKey()));
+            }
+            RoutineSectionResponse sectionResponse = new RoutineSectionResponse(
+                    routineTypeEntry.getKey(),
+                    routineProducts
+            );
+            switch (routineTypeEntry.getKey()) {
+                case AM -> amRoutine = sectionResponse;
+                case PM -> pmRoutine = sectionResponse;
+            }
+        }
+        if(amRoutine == null || pmRoutine == null) {
+            throw new RoutineException(RoutineErrorCode.ROUTINE_COMPOSITION_FAILED);
+        }
+
+        return new RoutineRecommendationResponse(
+                skinResult.getId(),
+                uxProfile.skinType(),
+                uxProfile.subtitle(),
+                uxProfile.routineSummary(),
+                amRoutine,
+                pmRoutine
+        );
+    }
+
+    private RoutineRecommendedProductResponse toProductResponse(
+            RecommendedProduct recommendedProduct,
+            RoutineStepCategory routineStepCategory
+    ) {
+        Product product = recommendedProduct.getProduct();
+        return new RoutineRecommendedProductResponse(
+                product.getId(),
+                product.getName(),
+                product.getCategory(),
+                product.getImageUrl(),
+                routineStepCategory
+        );
+    }
+
+    private SkinUxProfile resolveSkinUxProfile(SkinResult skinResult) {
+        List<SkinResultGroupScore> topGroupScores =
+                skinResultGroupScoreRepository.findTop2BySkinResultIdOrderByPriorityAsc(skinResult.getId());
+
+        if (topGroupScores.size() < 2) {
+            throw new RoutineException(RoutineErrorCode.ROUTINE_UX_PROFILE_NOT_FOUND);
+        }
+
+        IngredientGroup top1 = topGroupScores.get(0).getIngredientGroup();
+        IngredientGroup top2 = topGroupScores.get(1).getIngredientGroup();
+        if (top1 == null || top2 == null) {
+            throw new RoutineException(RoutineErrorCode.ROUTINE_UX_PROFILE_NOT_FOUND);
+        }
+
+        for (Map.Entry<SkinUxKey, SkinUxProfile> profileEntry : PROFILES.entrySet()) {
+            SkinUxKey uxKey = profileEntry.getKey();
+            if (uxKey.top1() == top1 && uxKey.top2() == top2) {
+                return profileEntry.getValue();
+            }
+        }
+
+        throw new RoutineException(RoutineErrorCode.ROUTINE_UX_PROFILE_NOT_FOUND);
+    }
+
+
+}

--- a/src/main/java/com/swyp3/skin/domain/skinresult/domain/exception/SkinResultErrorCode.java
+++ b/src/main/java/com/swyp3/skin/domain/skinresult/domain/exception/SkinResultErrorCode.java
@@ -9,6 +9,7 @@ import org.springframework.http.HttpStatus;
 @RequiredArgsConstructor
 public enum SkinResultErrorCode implements ErrorCode {
 
+    SKIN_RESULT_NOT_FOUND(HttpStatus.NOT_FOUND,"SKIN_RESULT_404_001", "진단결과를 찾을 수 없습니다."),
     SKIN_RESULT_NOT_YET(HttpStatus.NOT_FOUND,"SKIN_RESULT_404_001", "피부 진단을 아직 수행하지 않았습니다.");
 
 

--- a/src/main/java/com/swyp3/skin/domain/skinresult/repository/SkinResultRepository.java
+++ b/src/main/java/com/swyp3/skin/domain/skinresult/repository/SkinResultRepository.java
@@ -12,5 +12,5 @@ public interface SkinResultRepository extends JpaRepository<SkinResult,Long> {
 
     List<SkinResult> findTop4ByUser_IdOrderByCreatedAtDesc(Long userId);
 
-    Optional<SkinResult> findByIdAndUser_Id(Long id, Long userId);
+    Optional<SkinResult> findByIdAndUser_id(Long id, Long userId);
 }

--- a/src/main/java/com/swyp3/skin/domain/skinresult/service/SkinResultService.java
+++ b/src/main/java/com/swyp3/skin/domain/skinresult/service/SkinResultService.java
@@ -1,7 +1,6 @@
 package com.swyp3.skin.domain.skinresult.service;
 
 import com.swyp3.skin.domain.skinresult.domain.entity.SkinResult;
-import com.swyp3.skin.domain.skinresult.domain.entity.SkinResultGroupScore;
 import com.swyp3.skin.domain.skinresult.domain.exception.SkinResultErrorCode;
 import com.swyp3.skin.domain.skinresult.domain.exception.SkinResultException;
 import com.swyp3.skin.domain.skinresult.repository.SkinResultRepository;
@@ -37,11 +36,9 @@ public class SkinResultService {
         return skinResultRepository.findTop4ByUser_IdOrderByCreatedAtDesc(userId);
     }
 
-
-
-    public SkinResult findByIdAndUserId(Long resultId, Long userId) {
-        return skinResultRepository.findByIdAndUser_Id(resultId, userId)
-                .orElseThrow(()-> new SkinResultException(SkinResultErrorCode.SKIN_RESULT_NOT_YET));
+    public SkinResult getSkinResultById(Long skinResultId,Long userId) {
+        return skinResultRepository.findByIdAndUser_id(skinResultId,userId)
+                .orElseThrow(() -> new SkinResultException(SkinResultErrorCode.SKIN_RESULT_NOT_FOUND));
     }
 
 

--- a/src/main/java/com/swyp3/skin/domain/skintest/service/SkinTestApplicationService.java
+++ b/src/main/java/com/swyp3/skin/domain/skintest/service/SkinTestApplicationService.java
@@ -85,7 +85,7 @@ public class SkinTestApplicationService {
             SkinTestPreviewRequest previewRequest = toPreviewRequest(request);
             SkinInput skinInput = skinInputMapper.toSkinInput(previewRequest);
             RecommendationResult result = recommendationEngine.calculate(skinInput);
-            String typeName = previewResponseMapper.toResponse(result).typeName();
+            String typeName = previewResponseMapper.toResponse(result).skinType();
 
             return new ResolvedSkinResultData(
                     skinInput,

--- a/src/main/java/com/swyp3/skin/recommendation/ux/SkinUxProfile.java
+++ b/src/main/java/com/swyp3/skin/recommendation/ux/SkinUxProfile.java
@@ -7,16 +7,16 @@ import java.util.List;
 @Schema(description = "사용자 UX 프로필")
 public record SkinUxProfile(
         @Schema(description = "유형명", example = "촉촉한 수분 결핍형")
-        String typeName,
+        String skinType,
 
-        @Schema(description = "타입 설명", example = "속은 건조한데 겉은 번들거려요")
+        @Schema(description = "부제", example = "속은 건조한데 겉은 번들거려요")
         String subtitle,
 
-        @Schema(description = "피부설명")
+        @Schema(description = "피부 설명")
         String summary,
 
         @Schema(description = "루틴 설명")
-        String subSummary,
+        String routineSummary,
 
         @Schema(description = "루틴 원형 내용물")
         List<String> concerns,

--- a/src/main/resources/db/migration/V8__align_routine_schema_with_entities.sql
+++ b/src/main/resources/db/migration/V8__align_routine_schema_with_entities.sql
@@ -1,0 +1,9 @@
+ALTER TABLE routine_group
+    CHANGE COLUMN caution subtitle VARCHAR(100) NULL,
+    ADD COLUMN skin_type VARCHAR(100) NOT NULL AFTER skin_result_id;
+
+ALTER TABLE routine_product
+    DROP INDEX uk_routine_sort_order,
+    DROP COLUMN sort_order,
+    ADD COLUMN routine_step_category VARCHAR(50) NOT NULL AFTER product_id,
+    ADD UNIQUE KEY uk_routine_step_category (routine_id, routine_step_category);


### PR DESCRIPTION
## 관련 이슈
closes #101 

## 작업 내용
> 루틴 관련 기능 모두 구현
1. 루틴 추천
2. 루틴 저장
3. 루틴 조회 및 상세 조회
4. 루틴 삭제

## 변경 사항
- SkinUxProfile의 변수명을 기능 요구 사항과 맞추면서 skintest쪽 몇몇 변수들의 이름들이 변경되었습니다.

## 스크린샷 (UI 변경 시)

## 리뷰 요청 사항
- 루틴 추천 API                                                                                                                               
                                                                                                                                              
  - 최신 SkinResult를 기준으로 기존 상품 추천 결과를 다시 받아 루틴 후보를 만듭니다.                                                          
  - RoutineCompositionService에서 추천 상품을 AM/PM -> RoutineStepCategory로 재분류하고, 각 단계별 점수 상위 상품만 사용합니다.               
  - RoutineRecommendationService에서 상위 2개 성분군으로 SkinUxProfile을 찾아 루틴 설명을 붙입니다.                                           
  - AM/PM 둘 중 하나라도 완성되지 않으면 ROUTINE_COMPOSITION_FAILED로 실패 처리합니다.                                                        
  - 추천 응답은 바로 저장하지 않고 preview token과 함께 캐시에 넣고, 사용자가 저장 요청을 보내면 캐시의 내용을 바탕으로 저장 요청을 수행합니다.                                                                     
                                                                                                                                              
 **리뷰 포인트:**                                                                                                                                
                                                                                                                                              
      - RoutineType.from(productUsageTime) 분기                                                                                                   
      - RoutineStepCategory 매핑 기준                                                                                                             
      - top1 상품 선택 방식                                                                                                                       
      - SkinUxProfile 조회 실패 처리                                                                                                              
                                                                                                                                              
- 루틴 저장 API                                                                                                                               
                                                                                                                                              
  - 프론트에서 추천 시 받은  previewToken과 직접 입력한 title가 넘어옵니다.                                                                        
  - RoutineCommandService.save()에서 preview cache를 consume하고, 토큰 소유자와 현재 로그인 사용자가 같은지 검증합니다.                       
  - preview 응답 구조가 저장 가능한지 검증한 뒤 RoutineGroup -> Routine(AM/PM) -> RoutineProduct 순서로 저장합니다.                           
  - RoutineProduct는 sortOrder 대신 routineStepCategory를 저장하고, 정렬은 enum order를 사용합니다.                                           
                                                                                                                                              
 **리뷰 포인트:**                                                                                                                                
                                                                                                                                              
     - preview token 재사용 방지 방식                                                                                                            
     - validatePreviewResponse, validateSection 검증 범위                                                                                        
     - RoutineProduct 저장 구조가 routineStepCategory 중심으로 바뀐 점                                                                           
     - 저장 트랜잭션 범위                                                                                                                        
                                                                                                                                              
- 루틴 목록 조회 API                                                                                                                          
                                                                                                                                              
  - 사용자 기준 RoutineGroup을 페이지 단위로 조회합니다.                                                                                      
  - 정렬은 createdAt desc입니다.                                                                                                              
  - 목록 응답은 최소 정보만 주고, 상세 데이터는 별도 API에서 조회합니다.
                                                                                                                                              
 **리뷰 포인트:**                                                                                                                                

     - findByUser_Id(Pageable) 사용                                                                                                         
     - 응답 메타정보(page, size, totalElements, totalPages) 조립                                                                                 
                                                                                                                                              
- 루틴 상세 조회 API                                                                                                                          
                                                                                                                                              
  - routineGroupId + userId로 소유권 검증 후 조회합니다.                                                                                      
  - 그룹 하위 Routine들을 가져오고, 각 Routine의 RoutineProduct를 조회해서 AM/PM으로 나눕니다.                                                
  - 상품 정렬은 routineStepCategory.order 기준입니다.                                                                                         
                                                                                                                                              
 **리뷰 포인트:**                                                                                                                             

     - 상세 조회 권한 체크                                                                                                                       
     - RoutineProduct -> RoutineRecommendedProductResponse 변환                                                                                  
     - routineStepCategory 기반 정렬                                                                                                             
                                                                                                                                              
- 루틴 삭제 API                                                                                                                               
                                                                                                                                              
  - routineGroupId + userId로 삭제 권한 검증합니다.                                                                                           
  - 그룹 하위 Routine을 찾고, 각 Routine의 RoutineProduct를 bulk delete 후 Routine과 RoutineGroup을 삭제합니다.                               
                                                                                                                                              
 **리뷰 포인트:**                                                                                                                                    

     - 소유권 검증                                                                                                                                                                                                                                                               
     - deleteByRoutine_Id(...)로 하위 상품을 bulk delete하는 방식

- 스키마/모델 변경                                                                                                                            
                                                                                                                                              
  - routine_group.caution을 subtitle로 변경                                                                                                   
  - routine_group.skin_type 추가                                                                                                              
  - routine_product.sort_order 제거                                                                                                           
  - routine_product.routine_step_category 추가 및 (routine_id, routine_step_category) unique 제약 추가                                        
                                                                                                                                              
 **리뷰 포인트:**                                                                                                                                   
                                                                                                                                              
     - DB 스키마와 엔티티 정합성
     - sortOrder와 카테고리별 루틴 단계의 의도가 겹치므로 하나로 통합.
     - 피그마의 루틴 ui/ux 구조에 맞게 구조 변경.                                                                         
                                                                                                                                              
- 공유 변경                                                                                                                                   
                                                                                                                                           
  - SkinUxProfile 명칭을 루틴 쪽 의미에 맞게 정리하면서 skinTest 응답도 이름을 같이 맞췄습니다. 
  
- 추가 사항
     - **routine의 memo는 현재 null값**으로 그냥 열어둔 상태입니다.
     - 또한 **routine_product의 note와 reason역시 정해진 값이 없고  null**입니다. 
     -  **아직 테스트 코드가 없습니다.** 시험이 끝나지 않아서 담주중으로 최대한 처리하겠습니다..

## 체크리스트
- [ ] 컨벤션에 맞게 작성했나요?
- [ ] 불필요한 코드(주석, 디버그 로그)를 제거했나요?
- [ ] 테스트를 완료했나요?