### PR TITLE
Refactor/142 recommend product calculator

### DIFF
--- a/src/main/java/com/swyp3/skin/recommendation/product/calculator/ProductScoreCalculator.java
+++ b/src/main/java/com/swyp3/skin/recommendation/product/calculator/ProductScoreCalculator.java
@@ -3,12 +3,14 @@ package com.swyp3.skin.recommendation.product.calculator;
 import com.swyp3.skin.domain.common.enums.IngredientGroup;
 import com.swyp3.skin.recommendation.product.dto.ProductScore;
 import com.swyp3.skin.recommendation.product.dto.ProductSupply;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
+@Slf4j
 @Component
 public class ProductScoreCalculator {
 
@@ -17,11 +19,27 @@ public class ProductScoreCalculator {
             List<ProductSupply> supplies
     ) {
 
+        // top 3 추출
+        List<IngredientGroup> topGroups = need.entrySet().stream()
+                .sorted(Map.Entry.<IngredientGroup, Double>comparingByValue().reversed())
+                .limit(3)
+                .map(Map.Entry::getKey)
+                .toList();
+
+        IngredientGroup top1 = topGroups.get(0);
+        IngredientGroup top2 = topGroups.get(1);
+
         List<ProductScore> result = new ArrayList<>();
 
         for (ProductSupply supply : supplies) {
 
-            double score = dotProduct(need, supply.getSupply());
+            double score = calculateScore(
+                    need,
+                    supply.getSupply(),
+                    topGroups,
+                    top1,
+                    top2
+            );
 
             result.add(new ProductScore(
                     supply.getProductId(),
@@ -32,19 +50,59 @@ public class ProductScoreCalculator {
         return result;
     }
 
-    private double dotProduct(
+    private double calculateScore(
             Map<IngredientGroup, Double> need,
-            Map<IngredientGroup, Double> supply
-    ) {
-        double sum = 0.0;
+            Map<IngredientGroup, Double> supply,
+            List<IngredientGroup> topGroups,
+            IngredientGroup top1,
+            IngredientGroup top2) {
 
-        for (IngredientGroup group : need.keySet()) {
-            double n = need.getOrDefault(group, 0.0);
-            double s = supply.getOrDefault(group, 0.0);
+        double core = 0.0; // 중요한 성분 매칭
+        double rest = 0.0; // 덜 중요한 성분 매칭
 
-            sum += n * s;
+        for (IngredientGroup ingredientGroup : need.keySet()) {
+            Double n = need.getOrDefault(ingredientGroup, 0.0);
+            Double s = supply.getOrDefault(ingredientGroup, 0.0);
+
+            // 상품 성분군에 없는 제품은 아예 제거
+            double value = n * s;
+
+            // 중요한 성분을 따로 모아서 강하게 반영 준비
+            // 사용자에게 필요한 성분이라면 중요성분이 아니더라도 일단 반영은 하기
+            // 대신에 rest로 분류
+            if (topGroups.contains(ingredientGroup)) {
+                core += value;
+            } else {
+                rest += value;
+            }
         }
 
-        return sum;
+        double score = (core * 1.2) + (rest * 0.5);
+
+        // 상품이 사용자의 핵심성분을 얼마나 포함하고있는지 계산
+        double coverage = topGroups.stream()
+                .mapToDouble(group -> supply.getOrDefault(group, 0.0))
+                .sum();
+
+        // 낮으면 더낮게 조정
+        if (coverage < 0.2) {
+            score *= 0.5;
+        }
+
+        // 제일 중요한 성분을 갖고있다면 좀더 플러스
+        if (supply.containsKey(top1)) {
+            score += 0.1;
+        }
+
+        if (top2 != null && supply.containsKey(top2)) {
+            score += 0.05;
+        }
+
+        log.info("score = {}", score);
+
+        // 비선형 강화
+        return score * score;
     }
+
+
 }

--- a/src/main/java/com/swyp3/skin/recommendation/product/service/ProductRecommendationService.java
+++ b/src/main/java/com/swyp3/skin/recommendation/product/service/ProductRecommendationService.java
@@ -76,6 +76,7 @@ public class ProductRecommendationService {
 
         return scores.stream()
                 .sorted(Comparator.comparingDouble(ProductScore::getScore).reversed())
+                .limit(15)
                 .map(score -> new RecommendedProduct(
                         productMap.get(score.getProductId()),
                         score.getScore()


### PR DESCRIPTION
## 관련 이슈
closes #142 

## 작업 내용
> 상품 추천 계산 로직중 점수계산 파트를 개선 
> 상품추천은 최대 15개까지만 되도록 limit

## 변경 사항
- ProductScoreCalculator 에서 상품 추천도 계산시 단순 성분군 매칭 계산에서 필요성분 함량 스코어계산으로 변경
- 최종 결과값 반환시 15개 limit

## 스크린샷 (UI 변경 시)

## 리뷰 요청 사항
> 리뷰어가 집중해서 봐줬으면 하는 부분

## 체크리스트
- [ ] 컨벤션에 맞게 작성했나요?
- [ ] 불필요한 코드(주석, 디버그 로그)를 제거했나요?
- [ ] 테스트를 완료했나요?