### PR TITLE
feat: 고민 순위 속건조가 우선될 시 크림이 나오도록 구현

### DIFF
--- a/src/main/java/com/swyp3/skin/domain/routine/service/RoutineRecommendationService.java
+++ b/src/main/java/com/swyp3/skin/domain/routine/service/RoutineRecommendationService.java
@@ -1,6 +1,7 @@
 package com.swyp3.skin.domain.routine.service;
 
 import com.swyp3.skin.api.v1.routine.dto.response.*;
+import com.swyp3.skin.domain.product.domain.enums.ProductCategory;
 import com.swyp3.skin.domain.product.domain.entity.Product;
 import com.swyp3.skin.domain.routine.domain.enums.RoutineStepCategory;
 import com.swyp3.skin.domain.routine.domain.enums.RoutineType;
@@ -16,6 +17,8 @@ import org.springframework.stereotype.Service;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+
+import static com.swyp3.skin.recommendation.ux.SkinUxProfile.isPrimaryConcernInnerDryness;
 
 @Service
 @RequiredArgsConstructor
@@ -48,7 +51,9 @@ public class RoutineRecommendationService {
                 if(categoryProducts == null || categoryProducts.isEmpty()) {
                     throw new RoutineException(RoutineErrorCode.ROUTINE_DATA_INCOMPLETE);
                 }
-                routineProducts.add(toProductResponse(stepCategoryEntry.getValue().get(0), stepCategoryEntry.getKey()));
+                RecommendedProduct selectedProduct =
+                        selectRecommendedProduct(categoryProducts, stepCategoryEntry.getKey(), uxProfile);
+                routineProducts.add(toProductResponse(selectedProduct, stepCategoryEntry.getKey()));
             }
             RoutineSectionResponse sectionResponse = new RoutineSectionResponse(
                     routineTypeEntry.getKey(),
@@ -71,6 +76,17 @@ public class RoutineRecommendationService {
                 amRoutine,
                 pmRoutine
         );
+    }
+
+    private RecommendedProduct selectRecommendedProduct(List<RecommendedProduct> categoryProducts, RoutineStepCategory routineStepCategory,
+            SkinUxProfile uxProfile) {
+        if (routineStepCategory == RoutineStepCategory.MOISTURIZER && isPrimaryConcernInnerDryness(uxProfile)) {
+            return categoryProducts.stream()
+                    .filter(product -> product.getProduct().getCategory() == ProductCategory.CREAM)
+                    .findFirst()
+                    .orElse(categoryProducts.get(0));
+        }
+        return categoryProducts.get(0);
     }
 
     private RoutineRecommendedProductResponse toProductResponse(

--- a/src/main/java/com/swyp3/skin/recommendation/ux/SkinUxProfile.java
+++ b/src/main/java/com/swyp3/skin/recommendation/ux/SkinUxProfile.java
@@ -18,9 +18,13 @@ public record SkinUxProfile(
         @Schema(description = "루틴 설명")
         String routineSummary,
 
-        @Schema(description = "루틴 원형 내용물")
+        @Schema(description = "루틴 원형 내용물") //? 이게 왜 루틴 원형 내용물이지
         List<String> concerns,
 
         @Schema(description = "필요 성분 모음")
         List<IngredientType> ingredients
-) {}
+) {
+        public static boolean isPrimaryConcernInnerDryness(SkinUxProfile uxProfile) {
+                return !uxProfile.concerns().isEmpty() && "속건조".equals(uxProfile.concerns().get(0));
+        }
+}


### PR DESCRIPTION
## 관련 이슈
closes #147 

## 작업 내용
> 고민 순위 속건조가 우선될 시 크림이 나오도록 구현

## 변경 사항
- 루틴추천서비스에서 SkinUxProfile상 고민 우선순위 첫번째가 "속건조"일 시 크림으로 추천하도록 변경. 
- SkinUxProfile 1순위 고민이 "속건조"인지 확인하는 기능 추가

## 스크린샷 (UI 변경 시)

## 리뷰 요청 사항
> 리뷰어가 집중해서 봐줬으면 하는 부분

## 체크리스트
- [ ] 컨벤션에 맞게 작성했나요?
- [ ] 불필요한 코드(주석, 디버그 로그)를 제거했나요?
- [ ] 테스트를 완료했나요?