### PR TITLE
Bug/146 fix routine recommendation error

### DIFF
--- a/src/main/java/com/swyp3/skin/admin/product/service/AdminProductService.java
+++ b/src/main/java/com/swyp3/skin/admin/product/service/AdminProductService.java
@@ -4,6 +4,8 @@ import com.swyp3.skin.admin.product.dto.AdminProductCreateForm;
 import com.swyp3.skin.admin.product.dto.AdminProductUpdateForm;
 import com.swyp3.skin.domain.product.domain.entity.Product;
 import com.swyp3.skin.domain.product.domain.entity.ProductGroupScore;
+import com.swyp3.skin.domain.product.domain.enums.ProductCategory;
+import com.swyp3.skin.domain.product.domain.enums.ProductUsageTime;
 import com.swyp3.skin.domain.product.repository.ProductGroupScoreRepository;
 import com.swyp3.skin.domain.product.repository.ProductRepository;
 import lombok.RequiredArgsConstructor;
@@ -35,6 +37,7 @@ public class AdminProductService {
     @Transactional
     public Long update(Long productId, AdminProductUpdateForm form) {
         Product product = findById(productId);
+        validateSunCareUsageTime(form.category(), form.productUsageTime());
         product.update(
                 form.name(),
                 form.brand(),
@@ -62,6 +65,7 @@ public class AdminProductService {
     @Transactional
     public Long create(AdminProductCreateForm form) {
         validateGroupScores(form.groupScores());
+        validateSunCareUsageTime(form.category(), form.productUsageTime());
 
         Product product = Product.create(
                 form.name(),
@@ -92,6 +96,12 @@ public class AdminProductService {
             if (!unique.add(gs.ingredientGroup())) {
                 throw new IllegalArgumentException("성분군은 중복될 수 없습니다.");
             }
+        }
+    }
+
+    private void validateSunCareUsageTime(ProductCategory category, ProductUsageTime productUsageTime) {
+        if (category == ProductCategory.SUN_CARE && productUsageTime != ProductUsageTime.AM) {
+            throw new IllegalArgumentException("선크림은 루틴 시간대를 AM으로만 설정할 수 있습니다.");
         }
     }
 }

--- a/src/main/java/com/swyp3/skin/api/v1/skintest/mapper/SkinTestResultResponseMapper.java
+++ b/src/main/java/com/swyp3/skin/api/v1/skintest/mapper/SkinTestResultResponseMapper.java
@@ -30,7 +30,7 @@ public class SkinTestResultResponseMapper {
         return SkinTestResultResponse.of(today(), profile, ingredientMetas);
     }
 
-    // dtoㅇ내장으로 넣어도 될듯함 일단 보류
+    // dto 내장으로 넣어도 될듯함 일단 보류
     private static @NonNull List<IngredientMeta> getIngredientMetas(SkinUxProfile profile) {
         return profile.ingredients().stream()
                 .map(ingredientType -> {

--- a/src/main/java/com/swyp3/skin/domain/product/domain/entity/Product.java
+++ b/src/main/java/com/swyp3/skin/domain/product/domain/entity/Product.java
@@ -26,7 +26,7 @@ public class Product extends BaseEntity {
     private ProductCategory category;
 
     @Enumerated(EnumType.STRING)
-    @Column(length = 10)
+    @Column(length = 10, nullable = false)
     private ProductUsageTime productUsageTime;
 
     @Column(nullable = false)

--- a/src/main/java/com/swyp3/skin/domain/product/repository/ProductRepository.java
+++ b/src/main/java/com/swyp3/skin/domain/product/repository/ProductRepository.java
@@ -17,6 +17,7 @@ public interface ProductRepository extends JpaRepository<Product, Long> {
             )
         """)
     List<Product> search(String keyword);
+    List<Product> findAllByActiveTrue();
 
     long countByActiveTrue();
 }

--- a/src/main/java/com/swyp3/skin/domain/product/service/ProductRecommendCacheService.java
+++ b/src/main/java/com/swyp3/skin/domain/product/service/ProductRecommendCacheService.java
@@ -1,6 +1,7 @@
 package com.swyp3.skin.domain.product.service;
 
 import com.swyp3.skin.global.config.CacheConfig;
+import com.swyp3.skin.domain.product.domain.enums.ProductCategory;
 import com.swyp3.skin.recommendation.product.dto.RecommendedProduct;
 import com.swyp3.skin.recommendation.product.service.ProductRecommendationService;
 import lombok.RequiredArgsConstructor;
@@ -8,17 +9,37 @@ import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 
+import java.util.ArrayList;
+import java.util.EnumMap;
 import java.util.List;
+import java.util.Map;
 
 @Service
 @RequiredArgsConstructor
 public class ProductRecommendCacheService {
+    private final static int PER_CATEGORY_LIMIT = 5;
 
     private final ProductRecommendationService productRecommendationService;
 
     @Cacheable(cacheNames = CacheConfig.PRODUCT_RECOMMEND_CACHE, key = "#skinResultId")
     public List<RecommendedProduct> getOrCalculate(Long skinResultId) {
-        return productRecommendationService.recommend(skinResultId);
+        List<RecommendedProduct> recommended = productRecommendationService.recommend(skinResultId);
+        Map<ProductCategory, Integer> counts = new EnumMap<>(ProductCategory.class);
+        List<RecommendedProduct> top5ByCategory = new ArrayList<>();
+
+        for (RecommendedProduct product : recommended) {
+            ProductCategory category = product.getProduct().getCategory();
+            int count = counts.getOrDefault(category, 0);
+
+            if (count >= PER_CATEGORY_LIMIT) {
+                continue;
+            }
+
+            top5ByCategory.add(product);
+            counts.put(category, count + 1);
+        }
+
+        return top5ByCategory;
     }
 
     @CacheEvict(cacheNames = CacheConfig.PRODUCT_RECOMMEND_CACHE, key = "#skinResultId")

--- a/src/main/java/com/swyp3/skin/domain/routine/service/RoutineCompositionService.java
+++ b/src/main/java/com/swyp3/skin/domain/routine/service/RoutineCompositionService.java
@@ -36,16 +36,17 @@ public class RoutineCompositionService {
             List<RecommendedProduct> recommendedProducts
     ) {
         Map<RoutineType, List<RecommendedProduct>> productsByRoutineType = new EnumMap<>(RoutineType.class);
+        for (RoutineType routineType : RoutineType.values()) {
+            productsByRoutineType.put(routineType, new ArrayList<>()); // 미리 초기화
+        }
 
         for (RecommendedProduct recommendedProduct : recommendedProducts) {
             ProductUsageTime usageTime = recommendedProduct.getProduct().getProductUsageTime();
             if(usageTime == null) {
                 throw new RoutineException(RoutineErrorCode.PRODUCT_USAGE_TIME_NOT_DEFINE);
             }
-
             for (RoutineType routineType : RoutineType.from(usageTime)) {
-                productsByRoutineType.computeIfAbsent(routineType, ignored -> new ArrayList<>())
-                        .add(recommendedProduct);
+                productsByRoutineType.get(routineType).add(recommendedProduct);
             }
         }
         return productsByRoutineType;

--- a/src/main/java/com/swyp3/skin/domain/routine/service/RoutineCompositionService.java
+++ b/src/main/java/com/swyp3/skin/domain/routine/service/RoutineCompositionService.java
@@ -52,7 +52,7 @@ public class RoutineCompositionService {
     }
 
     private Map<RoutineType, Map<RoutineStepCategory, List<RecommendedProduct>>> groupProductsByStepCategory(
-            Map<RoutineType, List<RecommendedProduct>> productsByRoutineType
+            Map<RoutineType, List<RecommendedProduct>> productsByRoutineType // RoutineType >> am pm 상품이 하나도 없는 경우도 만들어야함
     ) {
         Map<RoutineType, Map<RoutineStepCategory, List<RecommendedProduct>>> productsByStepCategory =
                 new EnumMap<>(RoutineType.class);
@@ -64,13 +64,16 @@ public class RoutineCompositionService {
                             ignored -> new EnumMap<>(RoutineStepCategory.class)
                     );
 
+            for(RoutineStepCategory routineStepCategory : RoutineStepCategory.values()) {
+                productsForStepCategory.put(routineStepCategory, new ArrayList<>());
+            }
+
             for (RecommendedProduct recommendedProduct : routineTypeEntry.getValue()) {
                 Product product = recommendedProduct.getProduct();
                 RoutineStepCategory routineStepCategory =
                         RoutineStepCategory.from(product.getCategory());
 
-                productsForStepCategory.computeIfAbsent(routineStepCategory, ignored -> new ArrayList<>())
-                        .add(recommendedProduct);
+                productsForStepCategory.get(routineStepCategory).add(recommendedProduct);
             }
         }
         return productsByStepCategory;

--- a/src/main/java/com/swyp3/skin/domain/routine/service/RoutineCompositionService.java
+++ b/src/main/java/com/swyp3/skin/domain/routine/service/RoutineCompositionService.java
@@ -19,9 +19,6 @@ import java.util.Map;
 @RequiredArgsConstructor
 @Service
 public class RoutineCompositionService {
-    //am pm 시간대가 모두 채워진다는 보장이 없음
-    //카테고리 별로 상품이 모두 채워져 있다는 보장이 없음
-
     public Map<RoutineType, Map<RoutineStepCategory, List<RecommendedProduct>>> compose(List<RecommendedProduct> recommendedProducts) {
         Map<RoutineType, List<RecommendedProduct>> productsByRoutineType =
                 groupProductsByRoutineType(recommendedProducts);
@@ -53,7 +50,7 @@ public class RoutineCompositionService {
     }
 
     private Map<RoutineType, Map<RoutineStepCategory, List<RecommendedProduct>>> groupProductsByStepCategory(
-            Map<RoutineType, List<RecommendedProduct>> productsByRoutineType // RoutineType >> am pm 상품이 하나도 없는 경우도 만들어야함
+            Map<RoutineType, List<RecommendedProduct>> productsByRoutineType
     ) {
         Map<RoutineType, Map<RoutineStepCategory, List<RecommendedProduct>>> productsByStepCategory =
                 new EnumMap<>(RoutineType.class);
@@ -66,6 +63,9 @@ public class RoutineCompositionService {
                     );
 
             for(RoutineStepCategory routineStepCategory : RoutineStepCategory.values()) {
+                if(routineTypeEntry.getKey() == RoutineType.PM && routineStepCategory == RoutineStepCategory.SUN_CARE) {
+                    continue;
+                }
                 productsForStepCategory.put(routineStepCategory, new ArrayList<>());
             }
 

--- a/src/main/java/com/swyp3/skin/recommendation/product/calculator/ProductScoreCalculator.java
+++ b/src/main/java/com/swyp3/skin/recommendation/product/calculator/ProductScoreCalculator.java
@@ -20,14 +20,11 @@ public class ProductScoreCalculator {
     ) {
 
         // top 3 추출
-        List<IngredientGroup> topGroups = need.entrySet().stream()
+        List<IngredientGroup> needTop3Group = need.entrySet().stream()
                 .sorted(Map.Entry.<IngredientGroup, Double>comparingByValue().reversed())
                 .limit(3)
                 .map(Map.Entry::getKey)
                 .toList();
-
-        IngredientGroup top1 = topGroups.get(0);
-        IngredientGroup top2 = topGroups.get(1);
 
         List<ProductScore> result = new ArrayList<>();
 
@@ -36,9 +33,7 @@ public class ProductScoreCalculator {
             double score = calculateScore(
                     need,
                     supply.getSupply(),
-                    topGroups,
-                    top1,
-                    top2
+                    needTop3Group
             );
 
             result.add(new ProductScore(
@@ -53,9 +48,8 @@ public class ProductScoreCalculator {
     private double calculateScore(
             Map<IngredientGroup, Double> need,
             Map<IngredientGroup, Double> supply,
-            List<IngredientGroup> topGroups,
-            IngredientGroup top1,
-            IngredientGroup top2) {
+            List<IngredientGroup> needTop3Group
+    ) {
 
         double core = 0.0; // 중요한 성분 매칭
         double rest = 0.0; // 덜 중요한 성분 매칭
@@ -70,7 +64,7 @@ public class ProductScoreCalculator {
             // 중요한 성분을 따로 모아서 강하게 반영 준비
             // 사용자에게 필요한 성분이라면 중요성분이 아니더라도 일단 반영은 하기
             // 대신에 rest로 분류
-            if (topGroups.contains(ingredientGroup)) {
+            if (needTop3Group.contains(ingredientGroup)) {
                 core += value;
             } else {
                 rest += value;
@@ -80,7 +74,7 @@ public class ProductScoreCalculator {
         double score = (core * 1.2) + (rest * 0.5);
 
         // 상품이 사용자의 핵심성분을 얼마나 포함하고있는지 계산
-        double coverage = topGroups.stream()
+        double coverage = needTop3Group.stream()
                 .mapToDouble(group -> supply.getOrDefault(group, 0.0))
                 .sum();
 
@@ -90,11 +84,13 @@ public class ProductScoreCalculator {
         }
 
         // 제일 중요한 성분을 갖고있다면 좀더 플러스
-        if (supply.containsKey(top1)) {
+        IngredientGroup needTop1 = needTop3Group.get(0);
+        IngredientGroup needTop2 = needTop3Group.get(1);
+        if (supply.containsKey(needTop1)) {
             score += 0.1;
         }
 
-        if (top2 != null && supply.containsKey(top2)) {
+        if (needTop2 != null && supply.containsKey(needTop2)) {
             score += 0.05;
         }
 

--- a/src/main/java/com/swyp3/skin/recommendation/product/dto/ProductSupply.java
+++ b/src/main/java/com/swyp3/skin/recommendation/product/dto/ProductSupply.java
@@ -1,6 +1,7 @@
 package com.swyp3.skin.recommendation.product.dto;
 
 import com.swyp3.skin.domain.common.enums.IngredientGroup;
+import com.swyp3.skin.domain.product.domain.enums.ProductCategory;
 import lombok.Getter;
 
 import java.util.Map;
@@ -9,10 +10,12 @@ import java.util.Map;
 public class ProductSupply {
 
     private final Long productId;
+    private final ProductCategory productCategory;
     private final Map<IngredientGroup, Double> supply;
 
-    public ProductSupply(Long productId, Map<IngredientGroup, Double> supply) {
+    public ProductSupply(Long productId, ProductCategory productCategory, Map<IngredientGroup, Double> supply) {
         this.productId = productId;
+        this.productCategory = productCategory;
         this.supply = supply;
     }
 }

--- a/src/main/java/com/swyp3/skin/recommendation/product/mapper/ProductVectorMapper.java
+++ b/src/main/java/com/swyp3/skin/recommendation/product/mapper/ProductVectorMapper.java
@@ -26,6 +26,8 @@ public class ProductVectorMapper {
 
         List<ProductGroupScore> scores =
                 productGroupScoreRepository.findByProductIdIn(productIds);
+        Map<Long, Product> productMap = products.stream()
+                .collect(Collectors.toMap(Product::getId, p -> p));
 
         Map<Long, List<ProductGroupScore>> grouped = scores.stream()
                 .collect(Collectors.groupingBy(
@@ -33,9 +35,9 @@ public class ProductVectorMapper {
                 ));
 
         List<ProductSupply> result = new ArrayList<>();
-
         for (Map.Entry<Long, List<ProductGroupScore>> entry : grouped.entrySet()) {
             Long productId = entry.getKey();
+            Product product = productMap.get(productId);
 
             Map<IngredientGroup, Double> supply = entry.getValue().stream()
                     .collect(Collectors.toMap(
@@ -43,7 +45,7 @@ public class ProductVectorMapper {
                             ProductGroupScore::getScore
                     ));
 
-            result.add(new ProductSupply(productId, supply));
+            result.add(new ProductSupply(productId, product.getCategory(), supply));
         }
         return result;
     }

--- a/src/main/java/com/swyp3/skin/recommendation/product/policy/ProductFilterPolicy.java
+++ b/src/main/java/com/swyp3/skin/recommendation/product/policy/ProductFilterPolicy.java
@@ -1,6 +1,7 @@
 package com.swyp3.skin.recommendation.product.policy;
 
 import com.swyp3.skin.domain.common.enums.IngredientGroup;
+import com.swyp3.skin.domain.product.domain.enums.ProductCategory;
 import com.swyp3.skin.recommendation.product.dto.ProductSupply;
 import org.springframework.stereotype.Component;
 
@@ -14,20 +15,30 @@ public class ProductFilterPolicy {
 
     public List<ProductSupply> filter(
             List<ProductSupply> supplies,
-            Map<IngredientGroup, Double> need){
+            Map<IngredientGroup, Double> need) {
 
-        Set<IngredientGroup> topGroups = need.entrySet().stream()
+        Set<IngredientGroup> top2Groups = need.entrySet().stream()
                 .sorted(Map.Entry.<IngredientGroup, Double>comparingByValue().reversed())
                 .limit(2)
                 .map(Map.Entry::getKey)
                 .collect(Collectors.toSet());
 
-        //커팅단계 일단 아무거라도 들어가있다면
+        //선크림은 애초에 탑4까지 확인하여 상품 살림.
+        Set<IngredientGroup> top4Groups = need.entrySet().stream()
+                .sorted(Map.Entry.<IngredientGroup, Double>comparingByValue().reversed())
+                .limit(4)
+                .map(Map.Entry::getKey)
+                .collect(Collectors.toSet());
+
         return supplies.stream()
-                .filter(supply ->
-                        supply.getSupply().keySet().stream()
-                                .anyMatch(topGroups::contains)
-                )
+                .filter(supply -> {
+                    Set<IngredientGroup> threshold =
+                            supply.getProductCategory() == ProductCategory.SUN_CARE
+                                    ? top4Groups
+                                    : top2Groups;
+                    return supply.getSupply().keySet().stream()
+                            .anyMatch(threshold::contains);
+                })
                 .collect(Collectors.toList());
     }
 }

--- a/src/main/java/com/swyp3/skin/recommendation/product/service/ProductRecommendationService.java
+++ b/src/main/java/com/swyp3/skin/recommendation/product/service/ProductRecommendationService.java
@@ -40,7 +40,7 @@ public class ProductRecommendationService {
         Map<IngredientGroup, Double> need = loadNeed(resultId);
 
         // 2. Product 추천 후보 조회
-        List<Product> products = productRepository.findAll();
+        List<Product> products = productRepository.findAllByActiveTrue();
 
         // 3. Supply 생성 해당 제품이 어떤 성분 얼마나 공급하는지
         List<ProductSupply> supplies =

--- a/src/main/java/com/swyp3/skin/recommendation/product/service/ProductRecommendationService.java
+++ b/src/main/java/com/swyp3/skin/recommendation/product/service/ProductRecommendationService.java
@@ -3,7 +3,7 @@ package com.swyp3.skin.recommendation.product.service;
 import com.swyp3.skin.domain.common.enums.IngredientGroup;
 import com.swyp3.skin.domain.product.domain.entity.Product;
 import com.swyp3.skin.domain.product.domain.enums.ProductCategory;
-import com.swyp3.skin.domain.product.repository.ProductGroupScoreRepository;
+import com.swyp3.skin.domain.product.domain.enums.ProductUsageTime;
 import com.swyp3.skin.domain.product.repository.ProductRepository;
 import com.swyp3.skin.domain.skinresult.domain.entity.SkinResultGroupScore;
 import com.swyp3.skin.domain.skinresult.repository.SkinResultGroupScoreRepository;
@@ -13,7 +13,6 @@ import com.swyp3.skin.recommendation.product.dto.ProductSupply;
 import com.swyp3.skin.recommendation.product.dto.RecommendedProduct;
 import com.swyp3.skin.recommendation.product.mapper.ProductVectorMapper;
 import com.swyp3.skin.recommendation.product.policy.ProductFilterPolicy;
-import jdk.jfr.Category;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -26,9 +25,9 @@ import java.util.stream.Collectors;
 @Service
 @RequiredArgsConstructor
 public class ProductRecommendationService {
+    private final static int PER_CATEGORY_LIMIT = 5;
 
     private final ProductRepository productRepository;
-    private final ProductGroupScoreRepository productGroupScoreRepository;
     private final SkinResultGroupScoreRepository skinResultGroupScoreRepository;
 
     private final ProductVectorMapper productVectorMapper;
@@ -83,27 +82,72 @@ public class ProductRecommendationService {
                         productMap.get(s.getProductId()).getCategory()
                 ));
 
-        // 카테고리별 5개로
-        int perCategoryLimit = 5;
-
         List<RecommendedProduct> merged = new ArrayList<>();
 
         for (Map.Entry<ProductCategory, List<ProductScore>> entry : grouped.entrySet()) {
-
-            List<RecommendedProduct> topByCategory = entry.getValue().stream()
-                    .sorted(Comparator.comparingDouble(ProductScore::getScore).reversed())
-                    .limit(perCategoryLimit)
-                    .map(score -> new RecommendedProduct(
-                            productMap.get(score.getProductId()),
-                            score.getScore()
-                    ))
-                    .toList();
-
-            merged.addAll(topByCategory);
+            merged.addAll(selectTopByCategory(entry.getValue(), productMap));
         }
 
         return merged.stream()
                 .sorted(Comparator.comparingDouble(RecommendedProduct::getScore).reversed())
                 .toList();
+    }
+
+    //여기서 상품 목록을 띄울 때 기존처럼 그냥 리미트 5개 되는지 확인!!
+    //여기서 상품 목록을 띄울 때 기존처럼 그냥 리미트 5개 되는지 확인!!
+    //여기서 상품 목록을 띄울 때 기존처럼 그냥 리미트 5개 되는지 확인!!
+    //리스트에는 ampm 구분이 없음. 넣을때만 구분하는거지
+    private List<RecommendedProduct> selectTopByCategory(
+            List<ProductScore> categoryScores,
+            Map<Long, Product> productMap
+    ) {
+        List<ProductScore> sorted = categoryScores.stream()
+                .sorted(Comparator.comparingDouble(ProductScore::getScore).reversed())
+                .toList();
+
+        List<RecommendedProduct> selected = new ArrayList<>();
+        int amCount = 0;
+        int pmCount = 0;
+
+        for (ProductScore score : sorted) {
+            Product product = productMap.get(score.getProductId());
+            ProductUsageTime usageTime = product.getProductUsageTime(); // 정책 상은 사용시간이 null 일 수 없음. db 반영예정.
+            boolean shouldInclude = false;
+
+            switch (usageTime) {
+                case AM -> {
+                    if (amCount < PER_CATEGORY_LIMIT) {
+                        amCount++;
+                        shouldInclude = true;
+                    }
+
+                }
+                case PM -> {
+                    if (pmCount < PER_CATEGORY_LIMIT) {
+                        pmCount++;
+                        shouldInclude = true;
+                    }
+                }
+                case BOTH -> {
+                    if (amCount < PER_CATEGORY_LIMIT) amCount++;
+                    if (pmCount < PER_CATEGORY_LIMIT) pmCount++;
+                    shouldInclude = true; // 둘 중 하나라도 슬롯 있으면 포함
+                }
+            }
+
+            if (shouldInclude) {
+                selected.add(new RecommendedProduct(product, score.getScore()));
+            }
+
+            if (amCount == PER_CATEGORY_LIMIT && pmCount == PER_CATEGORY_LIMIT) {
+                break;
+            }
+
+            if(product.getCategory() == ProductCategory.SUN_CARE && amCount == 5) {
+                break; // 선크림은 am루틴에만 포함. 5개가 채워지면 즉시 종료.
+            }
+        }
+
+        return selected;
     }
 }

--- a/src/main/resources/db/migration/V11__modify_product_usage_time.sql
+++ b/src/main/resources/db/migration/V11__modify_product_usage_time.sql
@@ -1,2 +1,10 @@
+UPDATE product
+SET product_usage_time = 'AM'
+WHERE category = 'SUN_CARE';
+
 ALTER TABLE product
     MODIFY COLUMN product_usage_time VARCHAR(10) NOT NULL;
+
+ALTER TABLE product
+    ADD CONSTRAINT chk_product_sun_care_usage_time
+        CHECK (category <> 'SUN_CARE' OR product_usage_time = 'AM');

--- a/src/main/resources/db/migration/V11__modify_product_usage_time.sql
+++ b/src/main/resources/db/migration/V11__modify_product_usage_time.sql
@@ -1,0 +1,2 @@
+ALTER TABLE product
+    MODIFY COLUMN product_usage_time VARCHAR(10) NOT NULL;


### PR DESCRIPTION
## 관련 이슈
closes #146 

## 작업 내용
>루틴 추천 오류에 대한 전반적인 내용 수정 및 보완 작업 + 그에 따른 상품 추천 로직 수정

## 변경 사항
- 루틴에서 카테고리 + 시간대별 Map을 생성할 때 루틴 스텝별로 반드시 초기화부터 시작하여 빈상품리스트를 만들고 생성하도록 변경. 상품 추천에서 가져온 상품 리스트를 바탕으로 이 빈리스트들에 하나라도 채워지지 않았다면 상품 부족으로 인한 예외가 발생하도록 함.

- 선크림의 특수성으로 인해 성분군 중 여드름 + 피지 + 각질은 커버할 수 없음. 만약 사용자의 need가 앞의 3개로 이뤄져 있다면 선크림이 추천되지 않는 문제를 해결하기 위해 선크림은 top4 성분까지 필터를 넓혀 확인하도록 변경. 새로운 가중 값을 가져오는 건은 현재 논리가 부족하기에 접근하기 조심스러웠고, 기존 로직에서 선크림만 예외적으로 넓은 값을 확인할 수 있도록 허용. 

- 상품을 추천할 때 상위 스코어 5개가 아닌 각 시간대별 상위 스코어 5개씩을 기준으로 변경. 단, both 상품이 상위 스코어라 포함될 시에는 양쪽 모두에 추가. 단, 상품추천 로직은 기존과 동일하게 적용하기 위해 ProductRecommendCacheService 기존의 5개 한도를 추가. 

- 상품을 findAll할 때, active가 true인 경우에만 가져오도록 수정. 

- 사용 시간대를 이제 NOT NULL로 변경(entity + db).

- 선크림은 상품 등록할 때 반드시 am만 입력 가능하도록 검증 로직 추가.

## 스크린샷 (UI 변경 시)

## 리뷰 요청 사항
> 리뷰어가 집중해서 봐줬으면 하는 부분

## 체크리스트
- [ ] 컨벤션에 맞게 작성했나요?
- [ ] 불필요한 코드(주석, 디버그 로그)를 제거했나요?
- [ ] 테스트를 완료했나요?